### PR TITLE
[#57] Changing package name for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lto-api",
+  "name": "@ltonetwork/lto.js",
   "version": "0.5.14",
   "description": "LTO library to generate key pairs and sign events",
   "scripts": {


### PR DESCRIPTION
Changes the name of the package on `package.json` in order to publish under new organization. This doesn't close https://github.com/ltonetwork/lto-api.js/issues/57 entirely, as Travis deploy has not been set yet.

The new package can be found at https://www.npmjs.com/package/@ltonetwork/lto.js

---