### PR TITLE
If the sponsor is replaced, remove the last proof

### DIFF
--- a/src/transactions/Transaction.ts
+++ b/src/transactions/Transaction.ts
@@ -61,6 +61,9 @@ export default abstract class Transaction {
     	if (!this.isSigned()) 
     		throw new Error("Transaction must be signed first");
 
+		if (this.sponsor)
+			this.proofs.pop(); // The sponsor is replaced. The last proof is from the old sponsor.
+
 		const signature = sponsorAccount.sign(this.toBinary());
 
 		this.sponsor = sponsorAccount.address;

--- a/src/transactions/index.ts
+++ b/src/transactions/index.ts
@@ -13,6 +13,7 @@ import Transfer from "./Transfer";
 import {ITxJSON} from "../../interfaces";
 
 export {
+    Transaction,
 	Anchor,
 	Association,
 	RevokeAssociation,


### PR DESCRIPTION
A sponsored tx should have 2 proofs, not more.