### PR TITLE
Anchor event chain

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -84,8 +84,7 @@ export interface IEventChainJSON extends IHash<any> {
 export interface IEventJSON {
   timestamp?: number;
   previous: string;
-  signKey?: string;
-  keyType?: string,
+  signKey?: IPublicAccount;
   signature?: string;
   hash?: string;
   mediaType: string;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -82,12 +82,13 @@ export interface IEventChainJSON extends IHash<any> {
 }
 
 export interface IEventJSON {
-  timestamp: number;
+  timestamp?: number;
   previous: string;
-  signkey?: string;
+  signKey?: string;
+  keyType?: string,
   signature?: string;
   hash?: string;
-  mediaType: string,
+  mediaType: string;
   data: string;
 }
 

--- a/src/events/Event.ts
+++ b/src/events/Event.ts
@@ -68,6 +68,10 @@ export default class Event {
 		);
 	}
 
+	public get subject(): Binary {
+		return this.signature.hash();
+	}
+
 	private get cypher(): Cypher {
 		switch (this.keyType) {
 		case "ed25519":

--- a/src/events/Event.ts
+++ b/src/events/Event.ts
@@ -1,6 +1,6 @@
 import * as convert from "../utils/convert";
 
-import {IBinary, IEventJSON, IPublicAccount, ISigner} from "../../interfaces";
+import {IBinary, IEventJSON, ISigner} from "../../interfaces";
 import EventChain from "./EventChain";
 import Binary from "../Binary";
 import {ED25519} from "../accounts/ed25519/ED25519";
@@ -77,14 +77,14 @@ export default class Event {
 
 	private get cypher(): Cypher {
 		switch (this.signKey.keyType) {
-			case "ed25519":
-				return new ED25519({publicKey: this.signKey.publicKey});
-			case "secp256k1":
-				return new ECDSA("secp256k1", {publicKey: this.signKey.publicKey});
-			case "secp256r1":
-				return new ECDSA("secp256r1", {publicKey: this.signKey.publicKey});
-			default:
-				throw Error(`Unsupported key type ${this.signKey.publicKey}`);
+		case "ed25519":
+			return new ED25519({publicKey: this.signKey.publicKey});
+		case "secp256k1":
+			return new ECDSA("secp256k1", {publicKey: this.signKey.publicKey});
+		case "secp256r1":
+			return new ECDSA("secp256r1", {publicKey: this.signKey.publicKey});
+		default:
+			throw Error(`Unsupported key type ${this.signKey.publicKey}`);
 		}
 	}
 
@@ -128,10 +128,7 @@ export default class Event {
 		return {
 			timestamp: this.timestamp,
 			previous: this.previous.base58,
-			signKey: {
-				publicKey: this.signKey?.publicKey.base58,
-				keyType: this.signKey?.keyType,
-			},
+			signKey: this.signKey ? { keyType: this.signKey.keyType, publicKey: this.signKey.publicKey.base58 } : undefined,
 			signature: this.signature?.base58,
 			hash: this.signKey ? this.hash.base58 : undefined,
 			mediaType: this.mediaType,
@@ -140,13 +137,15 @@ export default class Event {
 	}
 
 	public static from(data: IEventJSON): Event {
-		const event = Object.create(Event);
+		const event: Event = Object.create(Event);
 
 		event.timestamp = data.timestamp;
 		event.previous = Binary.fromBase58(data.previous);
 		if (data.signKey) {
-			event.signKey = Binary.fromBase58(data.signKey.publicKey);
-			event.keyType = data.signKey.keyType;
+			event.signKey = {
+				publicKey: Binary.fromBase58(data.signKey.publicKey),
+				keyType: data.signKey.keyType,
+			};
 		}
 		if (data.signature) event.signature = Binary.fromBase58(data.signature);
 		if (data.hash) event._hash = Binary.fromBase58(data.hash);

--- a/src/events/Event.ts
+++ b/src/events/Event.ts
@@ -69,6 +69,10 @@ export default class Event {
 	}
 
 	public get subject(): Binary {
+		if (!this.signature) {
+			throw new Error("Unable to get subject: event is not signed");
+		}
+
 		return this.signature.hash();
 	}
 

--- a/src/events/Event.ts
+++ b/src/events/Event.ts
@@ -108,6 +108,10 @@ export default class Event {
 		return this;
 	}
 
+	public isSigned(): boolean {
+		return !!this.signature;
+	}
+
 	public get parsedData() {
 		if (!this.mediaType.startsWith("application/json")) {
 			throw new Error(`Unable to parse data with media type "${this.mediaType}"`);

--- a/src/events/EventChain.ts
+++ b/src/events/EventChain.ts
@@ -69,7 +69,7 @@ export default class EventChain {
 	}
 
 	protected assertEvent(event: Event): void {
-		if (event.signature && !event.verifySignature()) {
+		if (event.isSigned() && !event.verifySignature()) {
 			throw new Error(`Invalid signature of event ${event.hash.base58}`);
 		}
 
@@ -86,6 +86,10 @@ export default class EventChain {
 		) {
 			throw new Error("Genesis event is not signed by chain creator");
 		}
+	}
+
+	public isSigned(): boolean {
+		return this.events.reduce((b, e) => b && e.isSigned(), true);
 	}
 
 	public isPartial(): boolean {

--- a/src/events/EventChain.ts
+++ b/src/events/EventChain.ts
@@ -86,7 +86,7 @@ export default class EventChain {
 
 		if (
 			event.previous === this.initialHash &&
-			!crypto.verifyEventChainId(EVENT_CHAIN_VERSION, this.id, Binary.fromBase58(event.signKey))
+			!crypto.verifyEventChainId(EVENT_CHAIN_VERSION, this.id, event.signKey.publicKey)
 		) {
 			throw new Error("Genesis event is not signed by chain creator");
 		}
@@ -101,7 +101,7 @@ export default class EventChain {
 
 		if (
 			this.events[0].previous === this.initialHash &&
-			!crypto.verifyEventChainId(EVENT_CHAIN_VERSION, this.id, this.events[0].signkey)
+			!crypto.verifyEventChainId(EVENT_CHAIN_VERSION, this.id, this.events[0].signKey.publicKey)
 		) {
 			throw new Error("Genesis event is not signed by chain creator");
 		}

--- a/src/events/EventChain.ts
+++ b/src/events/EventChain.ts
@@ -86,7 +86,7 @@ export default class EventChain {
 
 		if (
 			event.previous === this.initialHash &&
-			!crypto.verifyEventChainId(EVENT_CHAIN_VERSION, this.id, event.signkey)
+			!crypto.verifyEventChainId(EVENT_CHAIN_VERSION, this.id, Binary.fromBase58(event.signKey))
 		) {
 			throw new Error("Genesis event is not signed by chain creator");
 		}
@@ -164,8 +164,8 @@ export default class EventChain {
 		return map;
 	}
 
-	public static toJSON(chain: EventChain): IEventChainJSON {
-		const events = chain.events.length > 0 ? chain.events.map(event => event.toJSON()) : [];
+	public toJSON(chain: EventChain): IEventChainJSON {
+		const events = chain.events.map(event => event.toJSON());
 		return {
 			id: chain.id,
 			events,

--- a/src/events/EventChain.ts
+++ b/src/events/EventChain.ts
@@ -52,8 +52,12 @@ export default class EventChain {
 
 	public get subject(): Binary {
 		return this.events.length == 0
-			? new Binary(Binary.fromBase58(this.id).reverse()).hash()
+			? this.initialSubject
 			: this.events.slice(-1)[0].subject;
+	}
+
+	private get initialSubject(): Binary {
+		return new Binary(Binary.fromBase58(this.id).reverse()).hash();
 	}
 
 	public set(data: Partial<IEventChainJSON>): EventChain {
@@ -89,7 +93,20 @@ export default class EventChain {
 	}
 
 	public isSigned(): boolean {
-		return this.events.reduce((b, e) => b && e.isSigned(), true);
+		return this.events.every(e => e.isSigned());
+	}
+
+	public partial(start: Binary) {
+		const index = this.events.findIndex(e => e.hash.hex === start.hex);
+
+		if (index < 0) {
+			throw new Error(`Event ${start} is not part of this event chain`);
+		}
+
+		const chain = new EventChain(this.id);
+		chain.events = this.events.slice(index);
+
+		return chain;
 	}
 
 	public isPartial(): boolean {
@@ -98,6 +115,22 @@ export default class EventChain {
 
 	public isCreatedBy(account: ISigner): boolean {
 		return crypto.verifyEventChainId(EVENT_CHAIN_VERSION, this.id, Binary.fromBase58(account.publicKey));
+	}
+
+	public get anchorMap(): Array<{key: Binary, value: Binary}> {
+		const map: Array<{key: Binary, value: Binary}> = [];
+		let subject = this.initialSubject;
+
+		for (const event of this.events) {
+			map.push({key: subject, value: event.hash});
+			subject = event.subject;
+		}
+
+		if (this.isPartial()) {
+			map.shift(); // Subject of the first event is unknown in case of a partial event chain
+		}
+
+		return map;
 	}
 
 	public static from(data: IEventChainJSON[]): EventChain {

--- a/src/events/EventChain.ts
+++ b/src/events/EventChain.ts
@@ -133,6 +133,14 @@ export default class EventChain {
 		return map;
 	}
 
+	public static toJSON(chain: EventChain): IEventChainJSON {
+		const events = chain.events.length > 0 ? chain.events.map(event => event.toJSON()) : [];
+		return {
+			id: chain.id,
+			events,
+		};
+	}
+
 	public static from(data: IEventChainJSON[]): EventChain {
 		return new EventChain("").set(data);
 	}

--- a/src/events/EventChain.ts
+++ b/src/events/EventChain.ts
@@ -50,6 +50,12 @@ export default class EventChain {
 		return Binary.fromBase58(this.id).hash();
 	}
 
+	public get subject(): Binary {
+		return this.events.length == 0
+			? new Binary(Binary.fromBase58(this.id).reverse()).hash()
+			: this.events.slice(-1)[0].subject;
+	}
+
 	public set(data: Partial<IEventChainJSON>): EventChain {
 		if (data.id) this.id = data.id;
 

--- a/test/events/Event.spec.ts
+++ b/test/events/Event.spec.ts
@@ -41,7 +41,7 @@ describe('Event', () => {
 
   describe('#toBinary', () => {
     it('should generate a event normal event message', () => {
-      expect(event.toBinary()).to.deep.eq(Binary.fromBase58('XrkbS4dZyK1tgD9YtKTxS58WagTmuu6bPLDqPdytL4mseG8bzyo1tEpGR7LjyFKfGzsFR22r4QeDQejJwgUaAPXW1Pgrs5Hn5DgyrTHDoa8qVX5HobQ5pbYxJVNuUh9fGzx'));
+      expect(event.toBinary()).to.deep.eq(Binary.fromBase58('3MCbQyd2QXYWw64cjjWVyffE9ZfBBEUwgmZqeavE5Z9ejMJR834DzujgfxcE1KiVC4tvDpuy6rtvFN8nR6C8FhmL3jScMSdz4dmV873FVHuBiP6vPsAZbRoAexEFT7z5uyw1N'));
     });
 
     it('should throw an error when no signkey is set', () => {
@@ -52,7 +52,7 @@ describe('Event', () => {
 
   describe('#hash', () => {
     it('should generate a correct hash', () => {
-      expect(event.hash.base58).to.eq('373AsfttQVFT5G9pNVTpShzHT55LarnsVgoaHLnimXqU');
+      expect(event.hash.base58).to.eq('6FBgn23AioAGQtCHKM7zdQV7H5nq8iCimk62M2qhANGa');
     });
   });
 
@@ -69,9 +69,9 @@ describe('Event', () => {
 
       const res = event.signWith(account);
       expect(res).to.eq(event);
-      expect(event.signature.base58).to.eq('5GHfmXcLSMZkAfsXhsNchYJCj7KHsFoj1X7fAbQaCF8m9bcyw7DdezJ2sYLsdyMfDS3kj1DUU1S16EzH5Xnezri4');
+      expect(event.signature.base58).to.eq('5KpRyaiYTnrrdT3JUc5hyvW5tr3sqvgtrXZ9zErmmPyxAmouSio9vMP48ZJ7peYkaTRyRH4UD9JYEiJn6VxLpQiV');
       expect(event.signKey.keyType).to.eq('ed25519');
-      expect(event.signKey.publicKey).to.eq('2od6By8qGe5DLYj7LD9djxVLBWVx5Dsy3P1TMRWdBPX6');
+      expect(event.signKey.publicKey.base58).to.eq('2od6By8qGe5DLYj7LD9djxVLBWVx5Dsy3P1TMRWdBPX6');
 
       expect(event.verifySignature()).to.be.true;
     });

--- a/test/events/Event.spec.ts
+++ b/test/events/Event.spec.ts
@@ -11,7 +11,10 @@ describe('Event', () => {
   beforeEach(() => {
     event = new Event(new Binary(''), "application/octet-stream", '72gRWx4C1Egqz9xvUBCYVdgh7uLc5kmGbjXFhiknNCTW');
     event.timestamp = 1519862400;
-    event.signKey = 'FkU1XyfrCftc4pQKXCrrDyRLSnifX1SMvmx1CYiiyB3Y';
+    event.signKey = {
+      publicKey: Binary.fromBase58('FkU1XyfrCftc4pQKXCrrDyRLSnifX1SMvmx1CYiiyB3Y'),
+      keyType: "ed25519",
+    };
   });
 
   afterEach(() => {
@@ -38,7 +41,6 @@ describe('Event', () => {
 
   describe('#toBinary', () => {
     it('should generate a event normal event message', () => {
-      event.keyType = "ed25519";
       expect(event.toBinary()).to.deep.eq(Binary.fromBase58('XrkbS4dZyK1tgD9YtKTxS58WagTmuu6bPLDqPdytL4mseG8bzyo1tEpGR7LjyFKfGzsFR22r4QeDQejJwgUaAPXW1Pgrs5Hn5DgyrTHDoa8qVX5HobQ5pbYxJVNuUh9fGzx'));
     });
 
@@ -68,8 +70,8 @@ describe('Event', () => {
       const res = event.signWith(account);
       expect(res).to.eq(event);
       expect(event.signature.base58).to.eq('5GHfmXcLSMZkAfsXhsNchYJCj7KHsFoj1X7fAbQaCF8m9bcyw7DdezJ2sYLsdyMfDS3kj1DUU1S16EzH5Xnezri4');
-      expect(event.keyType).to.eq('ed25519');
-      expect(event.signKey).to.eq('2od6By8qGe5DLYj7LD9djxVLBWVx5Dsy3P1TMRWdBPX6');
+      expect(event.signKey.keyType).to.eq('ed25519');
+      expect(event.signKey.publicKey).to.eq('2od6By8qGe5DLYj7LD9djxVLBWVx5Dsy3P1TMRWdBPX6');
 
       expect(event.verifySignature()).to.be.true;
     });

--- a/test/events/Event.spec.ts
+++ b/test/events/Event.spec.ts
@@ -3,6 +3,7 @@ import { EventChain, Event } from '../../src/events';
 import { AccountFactoryED25519 } from '../../src/accounts';
 import Binary from "../../src/Binary";
 import * as sinon from 'sinon';
+import converters from "../../src/libs/converters";
 
 describe('Event', () => {
   let event: Event;
@@ -10,7 +11,7 @@ describe('Event', () => {
   beforeEach(() => {
     event = new Event(new Binary(''), "application/octet-stream", '72gRWx4C1Egqz9xvUBCYVdgh7uLc5kmGbjXFhiknNCTW');
     event.timestamp = 1519862400;
-    event.signkey = Binary.fromBase58('FkU1XyfrCftc4pQKXCrrDyRLSnifX1SMvmx1CYiiyB3Y');
+    event.signKey = 'FkU1XyfrCftc4pQKXCrrDyRLSnifX1SMvmx1CYiiyB3Y';
   });
 
   afterEach(() => {
@@ -37,6 +38,7 @@ describe('Event', () => {
 
   describe('#toBinary', () => {
     it('should generate a event normal event message', () => {
+      event.keyType = "ed25519";
       expect(event.toBinary()).to.deep.eq(Binary.fromBase58('XrkbS4dZyK1tgD9YtKTxS58WagTmuu6bPLDqPdytL4mseG8bzyo1tEpGR7LjyFKfGzsFR22r4QeDQejJwgUaAPXW1Pgrs5Hn5DgyrTHDoa8qVX5HobQ5pbYxJVNuUh9fGzx'));
     });
 
@@ -65,9 +67,9 @@ describe('Event', () => {
 
       const res = event.signWith(account);
       expect(res).to.eq(event);
-      expect(event.signature.base58).to.eq('4ZkBfQrnVpszDt7y3gVRyp1Qj23C1gW3ga1GM2gEBHbhminao1YENcEEF4cL9e9FMwJcTZ4KJofgCMdQoHuWGfqf');
+      expect(event.signature.base58).to.eq('5GHfmXcLSMZkAfsXhsNchYJCj7KHsFoj1X7fAbQaCF8m9bcyw7DdezJ2sYLsdyMfDS3kj1DUU1S16EzH5Xnezri4');
       expect(event.keyType).to.eq('ed25519');
-      expect(event.signkey.base58).to.eq('2od6By8qGe5DLYj7LD9djxVLBWVx5Dsy3P1TMRWdBPX6');
+      expect(event.signKey).to.eq('2od6By8qGe5DLYj7LD9djxVLBWVx5Dsy3P1TMRWdBPX6');
 
       expect(event.verifySignature()).to.be.true;
     });


### PR DESCRIPTION
Closes #97 

- adds `keyType` property on `Event`
- adds `subject()` getter to be used for writing to the public chain (in combination with the hash)