### PR TITLE
Submit unsigned

### DIFF
--- a/src/LTO.ts
+++ b/src/LTO.ts
@@ -2,7 +2,7 @@ import { Account, AccountFactoryED25519, AccountFactoryECDSA, AccountFactory } f
 import { PublicNode } from './node';
 import * as crypto from './utils/crypto';
 import { SEED_ENCRYPTION_ROUNDS, DEFAULT_MAINNET_NODE, DEFAULT_TESTNET_NODE } from './constants';
-import { IAccountIn, IPair, IHash, ITransfer } from '../interfaces';
+import { IAccountIn, IPair, IHash, ITransfer, ISigner, IPublicAccount } from '../interfaces';
 import {
   Anchor,
   Association,
@@ -12,7 +12,7 @@ import {
   Data,
   Lease,
   MappedAnchor,
-  MassTransfer,
+  MassTransfer, Register,
   RevokeAssociation,
   Sponsorship,
   Statement,
@@ -177,6 +177,13 @@ export default class LTO {
    */
   public mappedAnchor(sender: Account, ...anchors: IPair<Uint8Array>[]): Promise<MappedAnchor> {
     return new MappedAnchor(...anchors).signWith(sender).broadcastTo(this.node);
+  }
+
+  /**
+   * Register public keys on the blockchain.
+   */
+  public register(sender: Account, ...accounts: Array<IPublicAccount | ISigner>): Promise<Register> {
+    return new Register(...accounts).signWith(sender).broadcastTo(this.node);
   }
 
   /**

--- a/src/transactions/Transaction.ts
+++ b/src/transactions/Transaction.ts
@@ -58,7 +58,12 @@ export default abstract class Transaction {
   }
 
   public broadcastTo(node: PublicNode): Promise<this> {
-    return node.broadcast(this);
+    if (this.isSigned()) {
+      return node.broadcast(this);
+    }
+
+    if (node.apiKey === '') throw new Error('Node API key required to broadcast unsigned transactions');
+    return node.submit(this);
   }
 
   public sponsorWith(sponsorAccount: ISigner): this {


### PR DESCRIPTION
If the transaction isn't signed and the node API key is given, `tx.broadcastTo` will use the `/transactions/submit` endpoint.
This means that the node will pay the tx fees.