### PR TITLE
Account resolver

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -1,10 +1,6 @@
 export type TBinary = Uint8Array | number[];
 export type TKeyType = 'ed25519' | 'secp256k1' | 'secp256r1';
 
-export interface IHash<T> {
-  [key: string]: T;
-}
-
 export interface IAccountIn {
   address?: string;
   publicKey?: string | Uint8Array;
@@ -80,14 +76,24 @@ export interface IEventJSON {
   data: string;
 }
 
-export interface IMessageJSON {
+interface IMessageJSONBase {
   type: string;
   sender: IPublicAccount;
   recipient: string;
   timestamp: Date | string;
   signature: string;
+}
+
+interface IMessageJSONEncrypted extends IMessageJSONBase {
   encryptedData: string;
 }
+
+interface IMessageJSONUnencrypted extends IMessageJSONBase {
+  mediaType: string;
+  data: string;
+}
+
+export type IMessageJSON = IMessageJSONEncrypted | IMessageJSONUnencrypted;
 
 export interface ITransfer {
   recipient: string;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -57,11 +57,11 @@ export type IPair<T> = {
   value: T;
 };
 
-export interface ITxJSON extends IHash<any> {
+export interface ITxJSON extends Record<string, any> {
   type: number;
 }
 
-export interface IEventChainJSON extends IHash<any> {
+export interface IEventChainJSON extends Record<string, any> {
   id: string;
   events: Array<IEventJSON | { hash: string; state: string }>;
 }

--- a/src/Binary.ts
+++ b/src/Binary.ts
@@ -13,63 +13,63 @@ export default class Binary extends Uint8Array implements IBinary {
     }
   }
 
-  public get base58(): string {
+  get base58(): string {
     return encode(this, Encoding.base58);
   }
 
-  public get base64(): string {
+  get base64(): string {
     return encode(this, Encoding.base64);
   }
 
-  public get hex(): string {
+  get hex(): string {
     return encode(this, Encoding.hex);
   }
 
   /** Create a SHA256 hash */
-  public hash(): Binary {
+  hash(): Binary {
     return new Binary(sha256(new Uint8Array(this)));
   }
 
-  public toString(): string {
+  toString(): string {
     return new TextDecoder().decode(this);
   }
 
-  public slice(start?: number, end?: number): Binary {
+  slice(start?: number, end?: number): Binary {
     return new Binary(super.slice(start, end));
   }
 
-  public reverse(): Binary {
+  reverse(): Binary {
     return new Binary(super.reverse());
   }
 
-  public static from(arrayLike: ArrayLike<number> | Iterable<number> | string): Binary;
-  public static from<T>(arrayLike: ArrayLike<T> | string, mapfn?: (v: T, k: number) => number, thisArg?: any): Binary {
+  static from(arrayLike: ArrayLike<number> | Iterable<number> | string): Binary;
+  static from<T>(arrayLike: ArrayLike<T> | string, mapfn?: (v: T, k: number) => number, thisArg?: any): Binary {
     return new Binary(typeof arrayLike === 'string' ? arrayLike : super.from(arrayLike, mapfn, thisArg));
   }
 
-  public static fromBase58(value: string): Binary {
+  static fromBase58(value: string): Binary {
     return new Binary(decode(value, Encoding.base58));
   }
 
-  public static fromBase64(value: string): Binary {
+  static fromBase64(value: string): Binary {
     return new Binary(decode(value, Encoding.base64));
   }
 
-  public static fromHex(value: string): Binary {
+  static fromHex(value: string): Binary {
     return new Binary(decode(value, Encoding.hex));
   }
 
   // Big Endian
-  public static fromInt16(value: number): Binary {
+  static fromInt16(value: number): Binary {
     return new Binary(int16ToBytes(value));
   }
 
   // Big Endian
-  public static fromInt32(value: number): Binary {
+  static fromInt32(value: number): Binary {
     return new Binary(int32ToBytes(value));
   }
 
-  public static concat(...items: Array<ArrayLike<number>>): Binary {
+  static concat(...items: Array<ArrayLike<number>>): Binary {
     const length = items.reduce((sum, item) => sum + item.length, 0);
     const merged = new Binary(length);
 

--- a/src/LTO.ts
+++ b/src/LTO.ts
@@ -12,7 +12,8 @@ import {
   Data,
   Lease,
   MappedAnchor,
-  MassTransfer, Register,
+  MassTransfer,
+  Register,
   RevokeAssociation,
   Sponsorship,
   Statement,
@@ -75,7 +76,7 @@ export default class LTO {
   get accountResolver(): AccountResolver {
     this._accountResolver ??= new AccountResolver(
       this.networkId,
-      `${this.nodeAddress}/index/identities`,
+      `${this.nodeAddress}/index/identifiers`,
       this.accountFactories,
     );
 

--- a/src/LTO.ts
+++ b/src/LTO.ts
@@ -22,10 +22,10 @@ import Binary from './Binary';
 import { decryptSeed } from './utils/encrypt-seed';
 
 export default class LTO {
-  public readonly networkId: string;
+  readonly networkId: string;
   private _nodeAddress?: string;
   private _node?: PublicNode;
-  public accountFactories: { [_: string]: AccountFactory };
+  accountFactories: { [_: string]: AccountFactory };
 
   constructor(networkId = 'L') {
     this.networkId = networkId;
@@ -46,22 +46,22 @@ export default class LTO {
     };
   }
 
-  public set nodeAddress(url: string) {
+  set nodeAddress(url: string) {
     this._nodeAddress = url;
     this._node = new PublicNode(url);
   }
 
-  public get nodeAddress(): string {
+  get nodeAddress(): string {
     if (!this._nodeAddress) throw Error('Public node not configured');
     return this._nodeAddress;
   }
 
-  public set node(node: PublicNode) {
+  set node(node: PublicNode) {
     this._node = node;
     this._nodeAddress = node.url;
   }
 
-  public get node(): PublicNode {
+  get node(): PublicNode {
     if (!this._node) throw Error('Public node not configured');
     return this._node;
   }
@@ -85,7 +85,7 @@ export default class LTO {
   /**
    * Create an account.
    */
-  public account(settings: IAccountIn = {}): Account {
+  account(settings: IAccountIn = {}): Account {
     let account: Account;
 
     const keyType = settings.keyType ?? settings.parent?.keyType ?? 'ed25519';
@@ -122,7 +122,7 @@ export default class LTO {
   /**
    * Check if the address is valid for the current network.
    */
-  public isValidAddress(address: string): boolean {
+  isValidAddress(address: string): boolean {
     return crypto.isValidAddress(address, this.networkId);
   }
 
@@ -130,7 +130,7 @@ export default class LTO {
    * Transfer LTO from account to recipient.
    * Amount is number of LTO * 10^8.
    */
-  public transfer(
+  transfer(
     sender: Account,
     recipient: string | Account,
     amount: number,
@@ -142,7 +142,7 @@ export default class LTO {
   /**
    * Transfer LTO from one account to up to 100 recipients.
    */
-  public massTransfer(
+  massTransfer(
     sender: Account,
     transfers: ITransfer[],
     attachment: Uint8Array | string = '',
@@ -154,16 +154,16 @@ export default class LTO {
    * Burn LTO from account. *poof* it's gone.
    * Amount is number of LTO * 10^8.
    */
-  public burn(sender: Account, amount: number): Promise<Burn> {
+  burn(sender: Account, amount: number): Promise<Burn> {
     return new Burn(amount).signWith(sender).broadcastTo(this.node);
   }
 
   /**
    * Write one or more hashes to the blockchain.
    */
-  public anchor(sender: Account, ...anchors: Uint8Array[]): Promise<Anchor>;
-  public anchor(sender: Account, ...anchors: IPair<Uint8Array>[]): Promise<MappedAnchor>;
-  public anchor(sender: Account, ...anchors: Uint8Array[] | IPair<Uint8Array>[]): Promise<Anchor | MappedAnchor> {
+  anchor(sender: Account, ...anchors: Uint8Array[]): Promise<Anchor>;
+  anchor(sender: Account, ...anchors: IPair<Uint8Array>[]): Promise<MappedAnchor>;
+  anchor(sender: Account, ...anchors: Uint8Array[] | IPair<Uint8Array>[]): Promise<Anchor | MappedAnchor> {
     if (anchors.length === 0) throw new Error('No anchors provided');
 
     return anchors[0] instanceof Uint8Array
@@ -175,21 +175,21 @@ export default class LTO {
    * Write one or more hashes as key/value pair to the blockchain.
    * @deprecated use `anchor` instead
    */
-  public mappedAnchor(sender: Account, ...anchors: IPair<Uint8Array>[]): Promise<MappedAnchor> {
+  mappedAnchor(sender: Account, ...anchors: IPair<Uint8Array>[]): Promise<MappedAnchor> {
     return new MappedAnchor(...anchors).signWith(sender).broadcastTo(this.node);
   }
 
   /**
    * Register public keys on the blockchain.
    */
-  public register(sender: Account, ...accounts: Array<IPublicAccount | ISigner>): Promise<Register> {
+  register(sender: Account, ...accounts: Array<IPublicAccount | ISigner>): Promise<Register> {
     return new Register(...accounts).signWith(sender).broadcastTo(this.node);
   }
 
   /**
    * Issue an association between accounts.
    */
-  public associate(
+  associate(
     sender: Account,
     type: number,
     recipient: string | Account,
@@ -203,7 +203,7 @@ export default class LTO {
   /**
    * Revoke an association between accounts.
    */
-  public revokeAssociation(
+  revokeAssociation(
     sender: Account,
     type: number,
     recipient: string | Account,
@@ -215,7 +215,7 @@ export default class LTO {
   /**
    * Make a public statement on the blockchain.
    */
-  public makeStatement(
+  makeStatement(
     sender: Account,
     type: number,
     recipient?: string | Account,
@@ -228,35 +228,35 @@ export default class LTO {
   /**
    * Lease an amount to a public node for staking.
    */
-  public lease(sender: Account, recipient: string | Account, amount: number): Promise<Lease> {
+  lease(sender: Account, recipient: string | Account, amount: number): Promise<Lease> {
     return new Lease(recipient, amount).signWith(sender).broadcastTo(this.node);
   }
 
   /**
    * Cancel a staking lease.
    */
-  public cancelLease(sender: Account, leaseId: string): Promise<CancelLease> {
+  cancelLease(sender: Account, leaseId: string): Promise<CancelLease> {
     return new CancelLease(leaseId).signWith(sender).broadcastTo(this.node);
   }
 
   /**
    * Sponsor an account.
    */
-  public sponsor(sender: Account, recipient: string | Account): Promise<Sponsorship> {
+  sponsor(sender: Account, recipient: string | Account): Promise<Sponsorship> {
     return new Sponsorship(recipient).signWith(sender).broadcastTo(this.node);
   }
 
   /**
    * Stop sponsoring an account.
    */
-  public cancelSponsorship(sender: Account, recipient: string | Account): Promise<CancelSponsorship> {
+  cancelSponsorship(sender: Account, recipient: string | Account): Promise<CancelSponsorship> {
     return new CancelSponsorship(recipient).signWith(sender).broadcastTo(this.node);
   }
 
   /**
    * Get the current account balance.
    */
-  public async getBalance(account: Account | string): Promise<number> {
+  async getBalance(account: Account | string): Promise<number> {
     const address = account instanceof Account ? account.address : account;
     return (await this.node.get(`/addresses/balance/${address}`)).balance;
   }
@@ -264,14 +264,14 @@ export default class LTO {
   /**
    * Set account data.
    */
-  public setData(account: Account, data: IHash<number | boolean | string | Uint8Array>) {
+  setData(account: Account, data: IHash<number | boolean | string | Uint8Array>) {
     return new Data(data).signWith(account).broadcastTo(this.node);
   }
 
   /**
    * Get account data.
    */
-  public async getData(account: Account | string): Promise<IHash<number | boolean | string | Binary>> {
+  async getData(account: Account | string): Promise<IHash<number | boolean | string | Binary>> {
     const address = account instanceof Account ? account.address : account;
     const dataEntries = await this.node.get(`/addresses/data/${address}`);
     return Data.from({ type: Data.TYPE, data: dataEntries }).dict;

--- a/src/LTO.ts
+++ b/src/LTO.ts
@@ -2,7 +2,7 @@ import { Account, AccountFactoryED25519, AccountFactoryECDSA, AccountFactory } f
 import { PublicNode } from './node';
 import * as crypto from './utils/crypto';
 import { SEED_ENCRYPTION_ROUNDS, DEFAULT_MAINNET_NODE, DEFAULT_TESTNET_NODE } from './constants';
-import { IAccountIn, IPair, IHash, ITransfer, ISigner, IPublicAccount } from '../interfaces';
+import { IAccountIn, IPair, ITransfer, ISigner, IPublicAccount } from '../interfaces';
 import {
   Anchor,
   Association,
@@ -195,7 +195,7 @@ export default class LTO {
     recipient: string | Account,
     subject?: Uint8Array,
     expires?: Date | number,
-    data?: IHash<number | boolean | string | Uint8Array>,
+    data?: Record<string, number | boolean | string | Uint8Array>,
   ): Promise<Association> {
     return new Association(type, recipient, subject, expires, data ?? []).signWith(sender).broadcastTo(this.node);
   }
@@ -220,7 +220,7 @@ export default class LTO {
     type: number,
     recipient?: string | Account,
     subject?: Uint8Array,
-    data?: IHash<number | boolean | string | Uint8Array>,
+    data?: Record<string, number | boolean | string | Uint8Array>,
   ): Promise<Statement> {
     return new Statement(type, recipient, subject, data ?? []).signWith(sender).broadcastTo(this.node);
   }
@@ -264,14 +264,14 @@ export default class LTO {
   /**
    * Set account data.
    */
-  setData(account: Account, data: IHash<number | boolean | string | Uint8Array>) {
+  setData(account: Account, data: Record<string, number | boolean | string | Uint8Array>) {
     return new Data(data).signWith(account).broadcastTo(this.node);
   }
 
   /**
    * Get account data.
    */
-  async getData(account: Account | string): Promise<IHash<number | boolean | string | Binary>> {
+  async getData(account: Account | string): Promise<Record<string, number | boolean | string | Binary>> {
     const address = account instanceof Account ? account.address : account;
     const dataEntries = await this.node.get(`/addresses/data/${address}`);
     return Data.from({ type: Data.TYPE, data: dataEntries }).dict;

--- a/src/accounts/Account.ts
+++ b/src/accounts/Account.ts
@@ -8,18 +8,18 @@ import { buildRawAddress, getNetwork } from '../utils/crypto';
 import { ethereumAddress } from '../utils/external-address';
 
 export default class Account implements ISigner {
-  public readonly networkId: string;
-  public readonly keyType: TKeyType;
-  public readonly nonce: number | Binary;
+  readonly networkId: string;
+  readonly keyType: TKeyType;
+  readonly nonce: number | Binary;
 
-  public parent?: Account;
+  parent?: Account;
 
   constructor(
-    public readonly cypher: Cypher,
-    public readonly address: string,
-    public readonly signKey: IKeyPairBytes,
-    public readonly encryptKey: IKeyPairBytes,
-    public readonly seed?: string,
+    readonly cypher: Cypher,
+    readonly address: string,
+    readonly signKey: IKeyPairBytes,
+    readonly encryptKey: IKeyPairBytes,
+    readonly seed?: string,
     nonce: number | Uint8Array = 0,
   ) {
     this.keyType = cypher.keyType;
@@ -30,7 +30,7 @@ export default class Account implements ISigner {
   /**
    * Get encrypted seed with a password
    */
-  public encryptSeed(password: string): string {
+  encryptSeed(password: string): string {
     if (!this.seed) throw new Error('Account seed unknown');
     return encryptSeed(this.seed, password, SEED_ENCRYPTION_ROUNDS);
   }
@@ -38,7 +38,7 @@ export default class Account implements ISigner {
   /**
    * Get encoded seed
    */
-  public encodeSeed(encoding = Encoding.base58): string {
+  encodeSeed(encoding = Encoding.base58): string {
     if (!this.seed) throw new Error('Account seed unknown');
     return encode(new Binary(this.seed), encoding);
   }
@@ -50,16 +50,16 @@ export default class Account implements ISigner {
   /**
    * Sign a message
    */
-  public sign(message: string | Uint8Array): Binary;
-  public sign<T extends ISignable>(subject: T): T;
-  public sign(input: string | Uint8Array | ISignable): Binary | ISignable {
+  sign(message: string | Uint8Array): Binary;
+  sign<T extends ISignable>(subject: T): T;
+  sign(input: string | Uint8Array | ISignable): Binary | ISignable {
     return typeof input === 'object' && 'signWith' in input ? input.signWith(this) : this.signMessage(input);
   }
 
   /**
    * Verify a signature with a message
    */
-  public verify(message: string | Uint8Array, signature: Uint8Array): boolean {
+  verify(message: string | Uint8Array, signature: Uint8Array): boolean {
     return this.cypher.verifySignature(new Binary(message), signature);
   }
 
@@ -67,7 +67,7 @@ export default class Account implements ISigner {
    * Encrypt a message with the account's public key.
    * This message can only be decrypted with the account's private key.
    */
-  public encrypt(message: string | Uint8Array): Binary {
+  encrypt(message: string | Uint8Array): Binary {
     const encrypted = this.cypher.encryptMessage(new Binary(message));
     return encrypted instanceof Binary ? encrypted : new Binary(encrypted);
   }
@@ -76,7 +76,7 @@ export default class Account implements ISigner {
    * Decrypt a message with the account's private key.
    * This message can only be encrypted with the account's public key.
    */
-  public decrypt(message: Uint8Array): Binary {
+  decrypt(message: Uint8Array): Binary {
     const decrypted = this.cypher.decryptMessage(message);
     return decrypted instanceof Binary ? decrypted : new Binary(decrypted);
   }
@@ -84,25 +84,25 @@ export default class Account implements ISigner {
   /**
    * Base58 encoded public sign key
    */
-  public get publicKey(): string {
+  get publicKey(): string {
     return this.signKey.publicKey.base58;
   }
 
   /**
    * Base58 encoded private sign key
    */
-  public get privateKey(): string {
+  get privateKey(): string {
     return this.signKey.privateKey.base58;
   }
 
   /**
    * Get LTO DID of account
    */
-  public get did(): string {
+  get did(): string {
     return 'lto:did:' + this.address;
   }
 
-  public getAddressOnNetwork(network: string): string {
+  getAddressOnNetwork(network: string): string {
     const [namespace, reference] = network.split(':');
 
     if (['ethereum', 'eip155', 'solana', 'cosmos'].includes(namespace) && this.keyType !== 'secp256k1') {

--- a/src/accounts/AccountFactory.ts
+++ b/src/accounts/AccountFactory.ts
@@ -2,7 +2,7 @@ import Account from './Account';
 import { int32ToBytes } from '../utils/bytes';
 
 export default abstract class AccountFactory {
-  public readonly chainId: string;
+  readonly chainId: string;
 
   protected constructor(chainId: string) {
     this.chainId = chainId;

--- a/src/accounts/Cypher.ts
+++ b/src/accounts/Cypher.ts
@@ -1,7 +1,7 @@
 import { TKeyType } from '../../interfaces';
 
 export abstract class Cypher {
-  public readonly keyType: TKeyType;
+  readonly keyType: TKeyType;
 
   protected constructor(keyType: TKeyType) {
     this.keyType = keyType;

--- a/src/accounts/ecdsa/AccountFactoryECDSA.ts
+++ b/src/accounts/ecdsa/AccountFactoryECDSA.ts
@@ -13,7 +13,7 @@ import { wordlist } from '@scure/bip39/wordlists/english';
 import { DEFAULT_DERIVATION_PATH } from '../../constants';
 
 export default class AccountFactoryECDSA extends AccountFactory {
-  public readonly curve: 'secp256k1' | 'secp256r1';
+  readonly curve: 'secp256k1' | 'secp256r1';
   private readonly ec: typeof secp256k1;
 
   constructor(chainId: string, curve: 'secp256k1' | 'secp256r1') {
@@ -22,7 +22,7 @@ export default class AccountFactoryECDSA extends AccountFactory {
     this.ec = this.curve === 'secp256k1' ? secp256k1 : secp256r1;
   }
 
-  public createFromSeed(seed: string, nonce?: number | Uint8Array | string): Account {
+  createFromSeed(seed: string, nonce?: number | Uint8Array | string): Account {
     nonce ??= DEFAULT_DERIVATION_PATH;
 
     if (this.curve === 'secp256r1') throw new Error('secp256r1 is not supported for creating an account from seed');
@@ -43,7 +43,7 @@ export default class AccountFactoryECDSA extends AccountFactory {
     );
   }
 
-  public createFromPublicKey(publicKey: string | Uint8Array): Account {
+  createFromPublicKey(publicKey: string | Uint8Array): Account {
     const publicKeyBinary = typeof publicKey === 'string' ? Binary.fromBase58(publicKey) : new Binary(publicKey);
 
     const compressed: IKeyPairBytes = { publicKey: undefined };
@@ -62,7 +62,7 @@ export default class AccountFactoryECDSA extends AccountFactory {
     return new Account(cypher, address, compressed, compressed);
   }
 
-  public createFromPrivateKey(privateKey: string | Uint8Array): Account {
+  createFromPrivateKey(privateKey: string | Uint8Array): Account {
     return this.createAccountFromPrivateKey(privateKey);
   }
 
@@ -99,7 +99,7 @@ export default class AccountFactoryECDSA extends AccountFactory {
     return this.createFromSeed(seed);
   }
 
-  public create(): Account {
+  create(): Account {
     return this.curve === 'secp256r1' ? this.createRandomPrivateKey() : this.createRandomSeed();
   }
 }

--- a/src/accounts/ecdsa/ECDSA.ts
+++ b/src/accounts/ecdsa/ECDSA.ts
@@ -17,7 +17,7 @@ import { DecryptError } from '../../errors';
  */
 export class ECDSA extends Cypher {
   private readonly ec: typeof secp256k1;
-  public readonly sign: IKeyPairBytes;
+  readonly sign: IKeyPairBytes;
 
   constructor(curve: 'secp256r1' | 'secp256k1', sign: IKeyPairBytes) {
     super(curve);
@@ -26,7 +26,7 @@ export class ECDSA extends Cypher {
     this.ec = curve === 'secp256k1' ? secp256k1 : secp256r1;
   }
 
-  public createSignature(input: Uint8Array): Uint8Array {
+  createSignature(input: Uint8Array): Uint8Array {
     if (!this.sign.privateKey) throw new Error('Unable to sign: no private key');
 
     const hash = sha256(input);
@@ -35,14 +35,14 @@ export class ECDSA extends Cypher {
     return signature.toCompactRawBytes();
   }
 
-  public verifySignature(input: Uint8Array, signature: Uint8Array): boolean {
+  verifySignature(input: Uint8Array, signature: Uint8Array): boolean {
     const hash = sha256(input);
     const ecSignature = this.ec.Signature.fromCompact(signature);
 
     return this.ec.verify(ecSignature, hash, this.sign.publicKey);
   }
 
-  public encryptMessage(input: Uint8Array): Uint8Array {
+  encryptMessage(input: Uint8Array): Uint8Array {
     const ephemeralPrivateKey = this.ec.utils.randomPrivateKey();
     const ephemeralPublicKey = this.ec.getPublicKey(ephemeralPrivateKey, true);
 
@@ -63,7 +63,7 @@ export class ECDSA extends Cypher {
     return Binary.concat(ephemeralPublicKey, tag, ciphertext);
   }
 
-  public decryptMessage(encryptedMessage: Uint8Array): Uint8Array {
+  decryptMessage(encryptedMessage: Uint8Array): Uint8Array {
     const ephemeralPublicKey = encryptedMessage.slice(0, 33);
     const tag = encryptedMessage.slice(33, 65);
     const ciphertext = encryptedMessage.slice(65);

--- a/src/accounts/ed25519/AccountFactoryED25519.ts
+++ b/src/accounts/ed25519/AccountFactoryED25519.ts
@@ -20,7 +20,7 @@ export default class AccountFactoryED25519 extends AccountFactory {
     super(chainId);
   }
 
-  public createFromSeed(seed: string, nonce: number | Uint8Array = 0): Account {
+  createFromSeed(seed: string, nonce: number | Uint8Array = 0): Account {
     const keys = AccountFactoryED25519.buildSignKeyPairFromSeed(seed, nonce);
     const sign: IKeyPairBytes = {
       privateKey: keys.privateKey,
@@ -37,7 +37,7 @@ export default class AccountFactoryED25519 extends AccountFactory {
     return new Account(cypher, address, sign, encrypt, seed, nonce);
   }
 
-  public createFromPrivateKey(privateKey: string | Uint8Array): Account {
+  createFromPrivateKey(privateKey: string | Uint8Array): Account {
     const keys = AccountFactoryED25519.buildSignKeyPairFromPrivateKey(privateKey);
     const sign: IKeyPairBytes = {
       privateKey: keys.privateKey,
@@ -54,7 +54,7 @@ export default class AccountFactoryED25519 extends AccountFactory {
     return new Account(cypher, address, sign, encrypt);
   }
 
-  public createFromPublicKey(publicKey: string | Uint8Array): Account {
+  createFromPublicKey(publicKey: string | Uint8Array): Account {
     const publicKeyBinary = typeof publicKey === 'string' ? Binary.fromBase58(publicKey) : new Binary(publicKey);
 
     const sign: IKeyPairBytes = {
@@ -70,7 +70,7 @@ export default class AccountFactoryED25519 extends AccountFactory {
     return new Account(cypher, address, sign, encrypt);
   }
 
-  public create(numberOfWords = 15): Account {
+  create(numberOfWords = 15): Account {
     return this.createFromSeed(generateNewSeed(numberOfWords));
   }
 

--- a/src/accounts/ed25519/ED25519.ts
+++ b/src/accounts/ed25519/ED25519.ts
@@ -36,11 +36,11 @@ export class ED25519 extends Cypher {
     return nacl.box.open(ciphertext, nonce, epk, secretKey);
   }
 
-  public encryptMessage(input: Uint8Array): Uint8Array {
+  encryptMessage(input: Uint8Array): Uint8Array {
     return ED25519.seal(input, this.encrypt.publicKey);
   }
 
-  public decryptMessage(input: Uint8Array): Uint8Array {
+  decryptMessage(input: Uint8Array): Uint8Array {
     if (!this.encrypt.privateKey) throw new Error('Missing private key for decryption');
 
     const output = ED25519.sealOpen(input, this.encrypt.publicKey, this.encrypt.privateKey);
@@ -49,13 +49,13 @@ export class ED25519 extends Cypher {
     return output;
   }
 
-  public createSignature(input: Uint8Array): Uint8Array {
+  createSignature(input: Uint8Array): Uint8Array {
     if (!this.sign.privateKey) throw new Error('Missing private key for signing');
 
     return nacl.sign.detached(input, this.sign.privateKey);
   }
 
-  public verifySignature(input: Uint8Array, signature: Uint8Array): boolean {
+  verifySignature(input: Uint8Array, signature: Uint8Array): boolean {
     return nacl.sign.detached.verify(input, signature, this.sign.publicKey);
   }
 }

--- a/src/errors/LTOError.ts
+++ b/src/errors/LTOError.ts
@@ -15,7 +15,7 @@ function resolveData(data: any): string {
 }
 
 export default class LTOError extends Error {
-  public readonly data: any;
+  readonly data: any;
 
   constructor(message: string, data: any = null) {
     super(`${message}:\n${resolveData(data)}`);

--- a/src/events/Event.ts
+++ b/src/events/Event.ts
@@ -9,22 +9,22 @@ import { cypher } from '../accounts';
 
 export default class Event {
   /** Meta type of the data */
-  public mediaType: string;
+  mediaType: string;
 
   /** Data of the event */
-  public data: IBinary;
+  data: IBinary;
 
   /** Time when the event was signed */
-  public timestamp?: number;
+  timestamp?: number;
 
   /** Hash to the previous event */
-  public previous?: IBinary;
+  previous?: IBinary;
 
   /** key and its type used to sign the event */
-  public signKey?: { keyType: TKeyType; publicKey: IBinary };
+  signKey?: { keyType: TKeyType; publicKey: IBinary };
 
   /** Signature of the event */
-  public signature?: IBinary;
+  signature?: IBinary;
 
   /** Hash (see dynamic property) */
   private _hash?: IBinary;
@@ -47,11 +47,11 @@ export default class Event {
     return Object.create(this.prototype);
   }
 
-  public get hash(): Binary {
+  get hash(): Binary {
     return this._hash ?? new Binary(this.toBinary()).hash();
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (typeof this.data == 'undefined') throw new Error('Event cannot be converted to binary: data unknown');
 
     if (!this.signKey) throw new Error('Event cannot be converted to binary: sign key not set');
@@ -68,13 +68,13 @@ export default class Event {
     );
   }
 
-  public verifySignature(): boolean {
+  verifySignature(): boolean {
     if (!this.signature || !this.signKey) throw new Error(`Event ${this._hash?.base58} is not signed`);
 
     return cypher(this.signKey).verifySignature(this.toBinary(), this.signature);
   }
 
-  public signWith(account: ISigner): this {
+  signWith(account: ISigner): this {
     if (!this.timestamp) this.timestamp = Date.now();
 
     try {
@@ -92,23 +92,23 @@ export default class Event {
     return this;
   }
 
-  public addTo(chain: EventChain): this {
+  addTo(chain: EventChain): this {
     chain.add(this);
     return this;
   }
 
-  public isSigned(): boolean {
+  isSigned(): boolean {
     return !!this.signature;
   }
 
-  public get parsedData() {
+  get parsedData() {
     if (!this.mediaType.startsWith('application/json'))
       throw new Error(`Unable to parse data with media type "${this.mediaType}"`);
 
     return JSON.parse(this.data.toString());
   }
 
-  public toJSON(): IEventJSON {
+  toJSON(): IEventJSON {
     return {
       timestamp: this.timestamp,
       previous: this.previous?.base58,
@@ -120,7 +120,7 @@ export default class Event {
     };
   }
 
-  public static from(data: IEventJSON): Event {
+  static from(data: IEventJSON): Event {
     const event = Event.create();
 
     try {

--- a/src/events/EventChain.ts
+++ b/src/events/EventChain.ts
@@ -13,10 +13,10 @@ const EVENT_CHAIN_VERSION = 0x41;
 const DERIVED_ID_VERSION = 0x51;
 
 export default class EventChain {
-  public readonly id: string;
-  public readonly networkId: string;
+  readonly id: string;
+  readonly networkId: string;
 
-  public events: Array<Event> = [];
+  events: Array<Event> = [];
   private partial?: { hash: IBinary; state: IBinary };
 
   constructor(id: string);
@@ -40,20 +40,20 @@ export default class EventChain {
   }
 
   /** @deprecated */
-  public static create(account: ISigner, nonce?: string | Uint8Array): EventChain {
+  static create(account: ISigner, nonce?: string | Uint8Array): EventChain {
     return new EventChain(account, nonce);
   }
 
-  public createDerivedId(nonce?: string): string {
+  createDerivedId(nonce?: string): string {
     const nonceBytes = nonce ? EventChain.createNonce(nonce) : EventChain.getRandomNonce();
     return EventChain.buildId(DERIVED_ID_VERSION, this.networkId, Binary.fromBase58(this.id), nonceBytes);
   }
 
-  public isDerivedId(id: string): boolean {
+  isDerivedId(id: string): boolean {
     return EventChain.validateId(DERIVED_ID_VERSION, this.networkId, id, Binary.fromBase58(this.id));
   }
 
-  public add(eventOrChain: Event | EventChain): EventChain {
+  add(eventOrChain: Event | EventChain): EventChain {
     if (this.events.length > 0 && !this.latestEvent.isSigned())
       throw new Error('Unable to add event: last event on chain is not signed');
 
@@ -90,12 +90,12 @@ export default class EventChain {
     }
   }
 
-  public has(event: IBinary | Event): boolean {
+  has(event: IBinary | Event): boolean {
     const hash = event instanceof Event ? event.hash : event;
     return !!this.events.find((event) => event.hash.hex === hash.hex);
   }
 
-  public get latestHash(): Binary {
+  get latestHash(): Binary {
     return this.events.length == 0 ? this.partial?.hash || this.initialHash : this.events.slice(-1)[0].hash;
   }
 
@@ -107,7 +107,7 @@ export default class EventChain {
     return this.events[this.events.length - 1];
   }
 
-  public get state(): Binary {
+  get state(): Binary {
     return this.events.length == 0
       ? this.partial?.state || this.initialState
       : this.stateAt(this.events[this.events.length - 1]);
@@ -131,7 +131,7 @@ export default class EventChain {
       throw new Error(`Invalid signature of event ${event.hash.base58}`);
   }
 
-  public validate(): void {
+  validate(): void {
     if (this.events.length === 0) throw new Error('No events on event chain');
 
     this.validateEvents();
@@ -166,15 +166,15 @@ export default class EventChain {
     }
   }
 
-  public isSigned(): boolean {
+  isSigned(): boolean {
     return this.events.every((e) => e.isSigned());
   }
 
-  public startingWith(start: Binary | Event): EventChain {
+  startingWith(start: Binary | Event): EventChain {
     return this.createPartial(start, 0);
   }
 
-  public startingAfter(start: Binary | Event): EventChain {
+  startingAfter(start: Binary | Event): EventChain {
     return this.createPartial(start, 1);
   }
 
@@ -199,11 +199,11 @@ export default class EventChain {
     return chain;
   }
 
-  public isPartial(): boolean {
+  isPartial(): boolean {
     return !!this.partial;
   }
 
-  public isCreatedBy(account: ISigner): boolean {
+  isCreatedBy(account: ISigner): boolean {
     return EventChain.validateId(
       EVENT_CHAIN_VERSION,
       getNetwork(account.address),
@@ -212,7 +212,7 @@ export default class EventChain {
     );
   }
 
-  public get anchorMap(): Array<{ key: Binary; value: Binary; signer: string }> {
+  get anchorMap(): Array<{ key: Binary; value: Binary; signer: string }> {
     const map: Array<{ key: Binary; value: Binary; signer: string }> = [];
     let state = this.partial?.state || this.initialState;
 
@@ -224,7 +224,7 @@ export default class EventChain {
     return map;
   }
 
-  public toJSON(): IEventChainJSON {
+  toJSON(): IEventChainJSON {
     const events: Array<IEventJSON | { hash: string; state: string }> = this.events.map((event) => event.toJSON());
 
     if (this.partial) events.unshift({ hash: this.partial.hash.base58, state: this.partial.state.base58 });
@@ -232,7 +232,7 @@ export default class EventChain {
     return { id: this.id, events };
   }
 
-  public static from(data: IEventChainJSON): EventChain {
+  static from(data: IEventChainJSON): EventChain {
     const chain = new EventChain(data.id);
 
     if (data.events.length === 0) return chain;

--- a/src/identities/AccountResolver.ts
+++ b/src/identities/AccountResolver.ts
@@ -1,0 +1,60 @@
+import { Account, AccountFactory, AccountFactoryECDSA, AccountFactoryED25519 } from '../accounts';
+import { RequestError } from '../errors';
+
+export default class AccountResolver {
+  constructor(
+    public readonly networkId: string,
+    public readonly url: string,
+    public accountFactories?: { [_: string]: AccountFactory },
+  ) {
+    this.accountFactories ??= {
+      ed25519: new AccountFactoryED25519(this.networkId),
+      secp256r1: new AccountFactoryECDSA(this.networkId, 'secp256r1'),
+      secp256k1: new AccountFactoryECDSA(this.networkId, 'secp256k1'),
+    };
+  }
+
+  // Can be overridden by mock for testing
+  private fetch(url: string, options: any): Promise<Response> {
+    return fetch(url, options);
+  }
+
+  private keyType(verificationMethodType: string) {
+    switch (verificationMethodType) {
+      case 'Ed25519VerificationKey2018':
+        return 'ed25519';
+      case 'EcdsaSecp256k1VerificationKey2019':
+        return 'secp256k1';
+    }
+  }
+
+  private getPublicKey(didDocument: any, methodId: string): { keyType?: string; publicKey?: string } {
+    const signMethod = didDocument.verificationMethod.find((method: any) => method.id === methodId);
+
+    if (!signMethod) return {};
+
+    if (!signMethod.publicKeyBase58) throw new Error(`Public key of ${methodId} is not base58 encoded`);
+
+    return {
+      keyType: this.keyType(signMethod.type),
+      publicKey: signMethod.publicKeyBase58,
+    };
+  }
+
+  async resolve(address: string): Promise<Account> {
+    const endpoint = `index/identities/${address}`;
+    const response = await this.fetch(`${this.url}/${endpoint}`, { method: 'GET' });
+
+    if (response.status === 404 && (await response.json()).error === 'notFound') {
+      throw new Error(`Public key of ${address} is unknown`);
+    }
+    if (!response.ok) throw new RequestError(`${this.url}/${endpoint}`, await response.json());
+
+    const did = await response.json();
+
+    const { keyType, publicKey } = this.getPublicKey(did, `${did.id}#sign`);
+    if (!publicKey) throw new Error(`Public sign key for ${address} not found in DID document 'did:lto:${address}'`);
+
+    return this.accountFactories[keyType].createFromPublicKey(publicKey);
+  }
+}

--- a/src/identities/AccountResolver.ts
+++ b/src/identities/AccountResolver.ts
@@ -42,17 +42,16 @@ export default class AccountResolver {
   }
 
   async resolve(address: string): Promise<Account> {
-    const endpoint = `index/identities/${address}`;
-    const response = await this.fetch(`${this.url}/${endpoint}`, { method: 'GET' });
+    const response = await this.fetch(`${this.url}/${address}`, { method: 'GET' });
 
     if (response.status === 404 && (await response.json()).error === 'notFound') {
       throw new Error(`Public key of ${address} is unknown`);
     }
-    if (!response.ok) throw new RequestError(`${this.url}/${endpoint}`, await response.json());
+    if (!response.ok) throw new RequestError(`${this.url}/${address}`, await response.json());
 
-    const did = await response.json();
+    const didDocument = await response.json();
 
-    const { keyType, publicKey } = this.getPublicKey(did, `${did.id}#sign`);
+    const { keyType, publicKey } = this.getPublicKey(didDocument, `${didDocument.id}#sign`);
     if (!publicKey) throw new Error(`Public sign key for ${address} not found in DID document 'did:lto:${address}'`);
 
     return this.accountFactories[keyType].createFromPublicKey(publicKey);

--- a/src/identities/IdentityBuilder.ts
+++ b/src/identities/IdentityBuilder.ts
@@ -4,19 +4,19 @@ import Transaction from '../transactions/Transaction';
 import Binary from '../Binary';
 
 export default class IdentityBuilder {
-  public readonly account: Account;
+  readonly account: Account;
   private newMethods: { account: Account; associationType: number }[] = [];
 
   constructor(account: Account) {
     this.account = account;
   }
 
-  public addVerificationMethod(secondaryAccount: Account, associationType = 0x100): this {
+  addVerificationMethod(secondaryAccount: Account, associationType = 0x100): this {
     this.newMethods.push({ account: secondaryAccount, associationType });
     return this;
   }
 
-  public get transactions(): Transaction[] {
+  get transactions(): Transaction[] {
     if (this.newMethods.length === 0)
       return [
         new Anchor(Binary.fromHex('f491f5a9fa2d782566ff516a8a708e6a82db407428ec5d8f365c7cdf2fe6ef99')).signWith(

--- a/src/identities/index.ts
+++ b/src/identities/index.ts
@@ -1,4 +1,5 @@
 export { default as IdentityBuilder } from './IdentityBuilder';
+export { default as AccountResolver } from './AccountResolver';
 
 export enum VerificationRelationship {
   none = 0x100,

--- a/src/messages/Message.ts
+++ b/src/messages/Message.ts
@@ -9,25 +9,25 @@ import { stringToByteArray, stringToByteArrayWithSize } from '../utils/convert';
 
 export default class Message {
   /** Type of the message */
-  public type?: string;
+  type?: string;
 
   /** Meta type of the data */
-  public mediaType?: string;
+  mediaType?: string;
 
   /** Data of the message */
-  public data?: IBinary;
+  data?: IBinary;
 
   /** Time when the message was signed */
-  public timestamp?: Date;
+  timestamp?: Date;
 
   /** Key and its type used to sign the event */
-  public sender?: { keyType: TKeyType; publicKey: IBinary };
+  sender?: { keyType: TKeyType; publicKey: IBinary };
 
   /** Signature of the message */
-  public signature?: IBinary;
+  signature?: IBinary;
 
   /** Address of the recipient */
-  public recipient?: string;
+  recipient?: string;
 
   private encryptedData?: IBinary;
 
@@ -75,7 +75,7 @@ export default class Message {
     return this;
   }
 
-  public verifySignature(): boolean {
+  verifySignature(): boolean {
     if (!this.signature || !this.sender) throw new Error('Message is not signed');
 
     return cypher(this.sender).verifySignature(this.toBinary(), this.signature);

--- a/src/node/PublicNode.ts
+++ b/src/node/PublicNode.ts
@@ -4,8 +4,8 @@ import { ITxJSON, IHash } from '../../interfaces';
 import { RequestError } from '../errors';
 
 export default class PublicNode {
-  public readonly url: string;
-  public readonly apiKey: string;
+  readonly url: string;
+  readonly apiKey: string;
 
   constructor(url: string, apiKey = '') {
     this.url = url.replace(/\/$/, '');
@@ -17,7 +17,7 @@ export default class PublicNode {
     return fetch(url, options);
   }
 
-  public async post(endpoint: string, postData: any, headers: IHash<string> = {}): Promise<any> {
+  async post(endpoint: string, postData: any, headers: IHash<string> = {}): Promise<any> {
     endpoint = endpoint.replace(/^\//, '');
     if (this.apiKey) headers['X-API-Key'] = this.apiKey;
     headers['content-type'] = 'application/json';
@@ -29,7 +29,7 @@ export default class PublicNode {
     return await response.json();
   }
 
-  public async get(endpoint: string, headers: IHash<string> = {}): Promise<any> {
+  async get(endpoint: string, headers: IHash<string> = {}): Promise<any> {
     endpoint = endpoint.replace(/^\//, '');
     if (this.apiKey) headers['X-API-Key'] = this.apiKey;
 
@@ -49,7 +49,7 @@ export default class PublicNode {
     return txFromData(data as ITxJSON) as T;
   }
 
-  public status(): Promise<{
+  status(): Promise<{
     blockchainHeight: number;
     stateHeight: number;
     updatedTimestamp: number;
@@ -58,7 +58,7 @@ export default class PublicNode {
     return this.get('/node/status');
   }
 
-  public async version(): Promise<string> {
+  async version(): Promise<string> {
     return (await this.get('/node/version')).version;
   }
 }

--- a/src/node/PublicNode.ts
+++ b/src/node/PublicNode.ts
@@ -1,6 +1,6 @@
 import Transaction from '../transactions/Transaction';
 import { txFromData } from '../transactions';
-import { ITxJSON, IHash } from '../../interfaces';
+import { ITxJSON } from '../../interfaces';
 import { RequestError } from '../errors';
 
 export default class PublicNode {
@@ -17,7 +17,7 @@ export default class PublicNode {
     return fetch(url, options);
   }
 
-  async post(endpoint: string, postData: any, headers: IHash<string> = {}): Promise<any> {
+  async post(endpoint: string, postData: any, headers: Record<string, string> = {}): Promise<any> {
     endpoint = endpoint.replace(/^\//, '');
     if (this.apiKey) headers['X-API-Key'] = this.apiKey;
     headers['content-type'] = 'application/json';
@@ -29,7 +29,7 @@ export default class PublicNode {
     return await response.json();
   }
 
-  async get(endpoint: string, headers: IHash<string> = {}): Promise<any> {
+  async get(endpoint: string, headers: Record<string, string> = {}): Promise<any> {
     endpoint = endpoint.replace(/^\//, '');
     if (this.apiKey) headers['X-API-Key'] = this.apiKey;
 

--- a/src/transactions/Anchor.ts
+++ b/src/transactions/Anchor.ts
@@ -11,9 +11,9 @@ const VAR_FEE = 10000000;
 const DEFAULT_VERSION = 3;
 
 export default class Anchor extends Transaction {
-  public static readonly TYPE = 15;
+  static readonly TYPE = 15;
 
-  public anchors: Binary[] = [];
+  anchors: Binary[] = [];
 
   constructor(...anchors: Uint8Array[]) {
     super(Anchor.TYPE, DEFAULT_VERSION, BASE_FEE + anchors.length * VAR_FEE);
@@ -53,7 +53,7 @@ export default class Anchor extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -66,7 +66,7 @@ export default class Anchor extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -85,7 +85,7 @@ export default class Anchor extends Transaction {
     };
   }
 
-  public static from(data: ITxJSON): Anchor {
+  static from(data: ITxJSON): Anchor {
     const anchors = (data.anchors ?? []).map(Binary.fromBase58);
     return new Anchor(...anchors).initFrom(data);
   }

--- a/src/transactions/Association.ts
+++ b/src/transactions/Association.ts
@@ -13,13 +13,13 @@ const VAR_BYTES = 256;
 const DEFAULT_VERSION = 3;
 
 export default class Association extends Transaction {
-  public static readonly TYPE = 16;
+  static readonly TYPE = 16;
 
-  public recipient: string;
-  public associationType: number;
-  public subject?: Binary;
-  public expires?: number;
-  public data: DataEntry[] = [];
+  recipient: string;
+  associationType: number;
+  subject?: Binary;
+  expires?: number;
+  data: DataEntry[] = [];
 
   constructor(
     associationType: number,
@@ -97,7 +97,7 @@ export default class Association extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -112,7 +112,7 @@ export default class Association extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -135,13 +135,13 @@ export default class Association extends Transaction {
     };
   }
 
-  public get dict(): IHash<number | boolean | string | Binary> {
+  get dict(): IHash<number | boolean | string | Binary> {
     const dictionary: IHash<number | boolean | string | Binary> = {};
     this.data.forEach((entry) => (dictionary[entry.key] = entry.value));
     return dictionary;
   }
 
-  public static from(data: ITxJSON): Association {
+  static from(data: ITxJSON): Association {
     const tx = new Association(
       data.associationType,
       data.recipient,

--- a/src/transactions/Association.ts
+++ b/src/transactions/Association.ts
@@ -3,7 +3,7 @@ import { concatBytes } from '@noble/hashes/utils';
 import { base58 } from '@scure/base';
 import * as convert from '../utils/convert';
 import { keyTypeId } from '../utils/crypto';
-import { IHash, ISigner, ITxJSON } from '../../interfaces';
+import { ISigner, ITxJSON } from '../../interfaces';
 import Binary from '../Binary';
 import { default as DataEntry, dictToData } from './DataEntry';
 
@@ -26,7 +26,7 @@ export default class Association extends Transaction {
     recipient: string | ISigner,
     subject?: Uint8Array,
     expires?: number | Date,
-    data: IHash<number | boolean | string | Uint8Array> | DataEntry[] = [],
+    data: Record<string, number | boolean | string | Uint8Array> | DataEntry[] = [],
   ) {
     super(Association.TYPE, DEFAULT_VERSION);
 
@@ -135,8 +135,8 @@ export default class Association extends Transaction {
     };
   }
 
-  get dict(): IHash<number | boolean | string | Binary> {
-    const dictionary: IHash<number | boolean | string | Binary> = {};
+  get dict(): Record<string, number | boolean | string | Binary> {
+    const dictionary: Record<string, number | boolean | string | Binary> = {};
     this.data.forEach((entry) => (dictionary[entry.key] = entry.value));
     return dictionary;
   }

--- a/src/transactions/Burn.ts
+++ b/src/transactions/Burn.ts
@@ -9,9 +9,9 @@ const DEFAULT_FEE = 100000000;
 const DEFAULT_VERSION = 3;
 
 export default class Burn extends Transaction {
-  public static readonly TYPE = 21;
+  static readonly TYPE = 21;
 
-  public amount: number;
+  amount: number;
 
   constructor(amount: number) {
     super(Burn.TYPE, DEFAULT_VERSION, DEFAULT_FEE);
@@ -29,7 +29,7 @@ export default class Burn extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -40,7 +40,7 @@ export default class Burn extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -59,7 +59,7 @@ export default class Burn extends Transaction {
     };
   }
 
-  public static from(data: ITxJSON): Burn {
+  static from(data: ITxJSON): Burn {
     return new Burn(data.amount).initFrom(data);
   }
 }

--- a/src/transactions/CancelLease.ts
+++ b/src/transactions/CancelLease.ts
@@ -9,9 +9,9 @@ const DEFAULT_FEE = 100000000;
 const DEFAULT_VERSION = 3;
 
 export default class CancelLease extends Transaction {
-  public static readonly TYPE = 9;
+  static readonly TYPE = 9;
 
-  public leaseId: string;
+  leaseId: string;
 
   constructor(leaseId: string) {
     super(CancelLease.TYPE, DEFAULT_VERSION, DEFAULT_FEE);
@@ -41,7 +41,7 @@ export default class CancelLease extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {

--- a/src/transactions/CancelSponsorship.ts
+++ b/src/transactions/CancelSponsorship.ts
@@ -9,9 +9,9 @@ const DEFAULT_FEE = 500000000;
 const DEFAULT_VERSION = 3;
 
 export default class CancelSponsorship extends Transaction {
-  public static readonly TYPE = 19;
+  static readonly TYPE = 19;
 
-  public recipient: string;
+  recipient: string;
 
   constructor(recipient: string | ISigner) {
     super(CancelSponsorship.TYPE, DEFAULT_VERSION, DEFAULT_FEE);
@@ -41,7 +41,7 @@ export default class CancelSponsorship extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -54,7 +54,7 @@ export default class CancelSponsorship extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -73,7 +73,7 @@ export default class CancelSponsorship extends Transaction {
     };
   }
 
-  public static from(data: ITxJSON): CancelSponsorship {
+  static from(data: ITxJSON): CancelSponsorship {
     return new CancelSponsorship(data.recipient).initFrom(data);
   }
 }

--- a/src/transactions/Data.ts
+++ b/src/transactions/Data.ts
@@ -3,7 +3,7 @@ import { concatBytes } from '@noble/hashes/utils';
 import { base58 } from '@scure/base';
 import * as convert from '../utils/convert';
 import { keyTypeId } from '../utils/crypto';
-import { IHash, ITxJSON } from '../../interfaces';
+import { ITxJSON } from '../../interfaces';
 import { default as DataEntry, dictToData } from './DataEntry';
 import Binary from '../Binary';
 
@@ -17,7 +17,7 @@ export default class Data extends Transaction {
 
   data: DataEntry[] = [];
 
-  constructor(data: IHash<number | boolean | string | Uint8Array> | DataEntry[]) {
+  constructor(data: Record<string, number | boolean | string | Uint8Array> | DataEntry[]) {
     super(Data.TYPE, DEFAULT_VERSION);
 
     this.data = Array.isArray(data) ? data : dictToData(data);
@@ -74,8 +74,8 @@ export default class Data extends Transaction {
     };
   }
 
-  get dict(): IHash<number | boolean | string | Binary> {
-    const dictionary: IHash<number | boolean | string | Binary> = {};
+  get dict(): Record<string, number | boolean | string | Binary> {
+    const dictionary: Record<string, number | boolean | string | Binary> = {};
     this.data.forEach((entry) => (dictionary[entry.key] = entry.value));
     return dictionary;
   }

--- a/src/transactions/Data.ts
+++ b/src/transactions/Data.ts
@@ -13,9 +13,9 @@ const VAR_BYTES = 256;
 const DEFAULT_VERSION = 3;
 
 export default class Data extends Transaction {
-  public static readonly TYPE = 12;
+  static readonly TYPE = 12;
 
-  public data: DataEntry[] = [];
+  data: DataEntry[] = [];
 
   constructor(data: IHash<number | boolean | string | Uint8Array> | DataEntry[]) {
     super(Data.TYPE, DEFAULT_VERSION);
@@ -44,7 +44,7 @@ export default class Data extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -55,7 +55,7 @@ export default class Data extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -74,13 +74,13 @@ export default class Data extends Transaction {
     };
   }
 
-  public get dict(): IHash<number | boolean | string | Binary> {
+  get dict(): IHash<number | boolean | string | Binary> {
     const dictionary: IHash<number | boolean | string | Binary> = {};
     this.data.forEach((entry) => (dictionary[entry.key] = entry.value));
     return dictionary;
   }
 
-  public static from(data: ITxJSON): Data {
+  static from(data: ITxJSON): Data {
     const tx = new Data([]).initFrom(data);
     tx.data = (data.data ?? []).map(DataEntry.from);
 

--- a/src/transactions/DataEntry.ts
+++ b/src/transactions/DataEntry.ts
@@ -1,7 +1,6 @@
 import * as convert from '../utils/convert';
 import { concatBytes } from '@noble/hashes/utils';
 import Binary from '../Binary';
-import { IHash } from '../../interfaces';
 
 type DataEntryType = 'integer' | 'boolean' | 'binary' | 'string';
 type DataEntryValue = number | boolean | Binary | string;
@@ -48,7 +47,7 @@ export default class DataEntry {
   static from(data: { key: string; type: DataEntryType; value: DataEntryValue }): DataEntry {
     const value =
       data.type === 'binary' && typeof data.value === 'string' && data.value.startsWith('base64:')
-        ? Binary.fromBase64(data.value.substr(7))
+        ? Binary.fromBase64(data.value.slice(7))
         : data.value;
 
     return new DataEntry(data.key, data.type, value);
@@ -83,7 +82,7 @@ export default class DataEntry {
   }
 }
 
-export function dictToData(dictionary: IHash<number | boolean | string | Uint8Array>): DataEntry[] {
+export function dictToData(dictionary: Record<string, number | boolean | string | Uint8Array>): DataEntry[] {
   const data: Array<DataEntry> = [];
 
   for (const key in dictionary) {

--- a/src/transactions/DataEntry.ts
+++ b/src/transactions/DataEntry.ts
@@ -8,9 +8,9 @@ type DataEntryValue = number | boolean | Binary | string;
 type DataEntryValueIn = number | boolean | Uint8Array | string;
 
 export default class DataEntry {
-  public key: string;
-  public type: DataEntryType;
-  public value: DataEntryValue;
+  key: string;
+  type: DataEntryType;
+  value: DataEntryValue;
 
   constructor(key: string, type: DataEntryType, value: DataEntryValueIn) {
     this.key = key;
@@ -18,7 +18,7 @@ export default class DataEntry {
     this.value = DataEntry.guard(key, type, value);
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     const keyBytes = convert.stringToByteArray(this.key);
 
     return concatBytes(convert.shortToByteArray(keyBytes.length), keyBytes, this.valueToBinary());
@@ -37,7 +37,7 @@ export default class DataEntry {
     }
   }
 
-  public toJSON(): { key: string; type: string; value: DataEntryValue } {
+  toJSON(): { key: string; type: string; value: DataEntryValue } {
     return {
       key: this.key,
       type: this.type,
@@ -45,7 +45,7 @@ export default class DataEntry {
     };
   }
 
-  public static from(data: { key: string; type: DataEntryType; value: DataEntryValue }): DataEntry {
+  static from(data: { key: string; type: DataEntryType; value: DataEntryValue }): DataEntry {
     const value =
       data.type === 'binary' && typeof data.value === 'string' && data.value.startsWith('base64:')
         ? Binary.fromBase64(data.value.substr(7))
@@ -54,7 +54,7 @@ export default class DataEntry {
     return new DataEntry(data.key, data.type, value);
   }
 
-  public static guess(key: string, value: any): DataEntry {
+  static guess(key: string, value: any): DataEntry {
     if (typeof value === 'number') return new DataEntry(key, 'integer', value);
     if (typeof value === 'boolean') return new DataEntry(key, 'boolean', value);
     if (typeof value === 'string') return new DataEntry(key, 'string', value);

--- a/src/transactions/Lease.ts
+++ b/src/transactions/Lease.ts
@@ -9,10 +9,10 @@ const DEFAULT_FEE = 100000000;
 const DEFAULT_VERSION = 3;
 
 export default class Lease extends Transaction {
-  public static readonly TYPE = 8;
+  static readonly TYPE = 8;
 
-  public recipient: string;
-  public amount: number;
+  recipient: string;
+  amount: number;
 
   constructor(recipient: string | ISigner, amount: number) {
     super(Lease.TYPE, DEFAULT_VERSION, DEFAULT_FEE);
@@ -44,7 +44,7 @@ export default class Lease extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -57,7 +57,7 @@ export default class Lease extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,

--- a/src/transactions/MappedAnchor.ts
+++ b/src/transactions/MappedAnchor.ts
@@ -3,7 +3,7 @@ import { concatBytes } from '@noble/hashes/utils';
 import { base58 } from '@scure/base';
 import * as convert from '../utils/convert';
 import { keyTypeId } from '../utils/crypto';
-import { IBinary, IHash, IPair, ITxJSON } from '../../interfaces';
+import { IBinary, IPair, ITxJSON } from '../../interfaces';
 import Binary from '../Binary';
 
 const BASE_FEE = 25000000;
@@ -60,7 +60,7 @@ export default class MappedAnchor extends Transaction {
   }
 
   toJSON(): ITxJSON {
-    const anchors: IHash<string> = {};
+    const anchors: Record<string, string> = {};
     this.anchors.forEach((pair) => (anchors[pair.key.base58] = pair.value.base58));
 
     return {

--- a/src/transactions/MappedAnchor.ts
+++ b/src/transactions/MappedAnchor.ts
@@ -11,9 +11,9 @@ const VAR_FEE = 10000000;
 const DEFAULT_VERSION = 3;
 
 export default class MappedAnchor extends Transaction {
-  public static readonly TYPE = 22;
+  static readonly TYPE = 22;
 
-  public anchors: IPair<IBinary>[];
+  anchors: IPair<IBinary>[];
 
   constructor(...anchors: IPair<Uint8Array>[]) {
     super(MappedAnchor.TYPE, DEFAULT_VERSION, BASE_FEE + anchors.length * VAR_FEE);
@@ -48,7 +48,7 @@ export default class MappedAnchor extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -59,7 +59,7 @@ export default class MappedAnchor extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     const anchors: IHash<string> = {};
     this.anchors.forEach((pair) => (anchors[pair.key.base58] = pair.value.base58));
 
@@ -81,7 +81,7 @@ export default class MappedAnchor extends Transaction {
     };
   }
 
-  public static from(data: ITxJSON): MappedAnchor {
+  static from(data: ITxJSON): MappedAnchor {
     const anchors = Object.entries(data.anchors).map(([key, value]) => ({
       key: Binary.fromBase58(key),
       value: Binary.fromBase58(value as string),

--- a/src/transactions/MassTransfer.ts
+++ b/src/transactions/MassTransfer.ts
@@ -11,10 +11,10 @@ const VAR_FEE = 10000000;
 const DEFAULT_VERSION = 3;
 
 export default class MassTransfer extends Transaction {
-  public static readonly TYPE = 11;
+  static readonly TYPE = 11;
 
-  public transfers: ITransfer[];
-  public attachment: Binary;
+  transfers: ITransfer[];
+  attachment: Binary;
 
   constructor(transfers: ITransfer[], attachment: Uint8Array | string = '') {
     super(MassTransfer.TYPE, DEFAULT_VERSION, BASE_FEE + transfers.length * VAR_FEE);
@@ -59,7 +59,7 @@ export default class MassTransfer extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -72,7 +72,7 @@ export default class MassTransfer extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -92,7 +92,7 @@ export default class MassTransfer extends Transaction {
     };
   }
 
-  public static from(data: ITxJSON): MassTransfer {
+  static from(data: ITxJSON): MassTransfer {
     const attachment = data.attachment ? Binary.fromBase58(data.attachment) : '';
     return new MassTransfer(data.transfers, attachment).initFrom(data);
   }

--- a/src/transactions/Register.ts
+++ b/src/transactions/Register.ts
@@ -10,9 +10,9 @@ const VAR_FEE = 10000000;
 const DEFAULT_VERSION = 3;
 
 export default class Register extends Transaction {
-  public static readonly TYPE = 20;
+  static readonly TYPE = 20;
 
-  public accounts: IPublicAccount[];
+  accounts: IPublicAccount[];
 
   constructor(...accounts: (IPublicAccount | ISigner)[]) {
     super(Register.TYPE, DEFAULT_VERSION, BASE_FEE + accounts.length * VAR_FEE);
@@ -46,7 +46,7 @@ export default class Register extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -57,7 +57,7 @@ export default class Register extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -76,7 +76,7 @@ export default class Register extends Transaction {
     };
   }
 
-  public static from(data: ITxJSON): Register {
+  static from(data: ITxJSON): Register {
     return new Register(...data.accounts).initFrom(data);
   }
 }

--- a/src/transactions/RevokeAssociation.ts
+++ b/src/transactions/RevokeAssociation.ts
@@ -10,11 +10,11 @@ const DEFAULT_FEE = 50000000;
 const DEFAULT_VERSION = 3;
 
 export default class RevokeAssociation extends Transaction {
-  public static readonly TYPE = 17;
+  static readonly TYPE = 17;
 
-  public recipient: string;
-  public associationType: number;
-  public subject?: Binary;
+  recipient: string;
+  associationType: number;
+  subject?: Binary;
 
   constructor(associationType: number, recipient: string | ISigner, subject?: Uint8Array) {
     super(RevokeAssociation.TYPE, DEFAULT_VERSION, DEFAULT_FEE);
@@ -71,7 +71,7 @@ export default class RevokeAssociation extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -84,7 +84,7 @@ export default class RevokeAssociation extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -105,7 +105,7 @@ export default class RevokeAssociation extends Transaction {
     };
   }
 
-  public static from(data: ITxJSON): RevokeAssociation {
+  static from(data: ITxJSON): RevokeAssociation {
     return new RevokeAssociation(
       data.associationType,
       data.recipient,

--- a/src/transactions/Sponsorship.ts
+++ b/src/transactions/Sponsorship.ts
@@ -9,9 +9,9 @@ const DEFAULT_FEE = 500000000;
 const DEFAULT_VERSION = 3;
 
 export default class Sponsorship extends Transaction {
-  public static readonly TYPE = 18;
+  static readonly TYPE = 18;
 
-  public recipient: string;
+  recipient: string;
 
   constructor(recipient: string | ISigner) {
     super(Sponsorship.TYPE, DEFAULT_VERSION, DEFAULT_FEE);
@@ -41,7 +41,7 @@ export default class Sponsorship extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -54,7 +54,7 @@ export default class Sponsorship extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -73,7 +73,7 @@ export default class Sponsorship extends Transaction {
     };
   }
 
-  public static from(data: ITxJSON): Sponsorship {
+  static from(data: ITxJSON): Sponsorship {
     return new Sponsorship(data.recipient).initFrom(data);
   }
 }

--- a/src/transactions/Statement.ts
+++ b/src/transactions/Statement.ts
@@ -3,7 +3,7 @@ import { concatBytes } from '@noble/hashes/utils';
 import { base58 } from '@scure/base';
 import * as convert from '../utils/convert';
 import { keyTypeId } from '../utils/crypto';
-import { IHash, ISigner, ITxJSON } from '../../interfaces';
+import { ISigner, ITxJSON } from '../../interfaces';
 import Binary from '../Binary';
 import { default as DataEntry, dictToData } from './DataEntry';
 
@@ -24,7 +24,7 @@ export default class Statement extends Transaction {
     statementType: number,
     recipient: string | ISigner,
     subject?: Uint8Array,
-    data: IHash<number | boolean | string | Uint8Array> | DataEntry[] = [],
+    data: Record<string, number | boolean | string | Uint8Array> | DataEntry[] = [],
   ) {
     super(Statement.TYPE, DEFAULT_VERSION);
 
@@ -94,8 +94,8 @@ export default class Statement extends Transaction {
     };
   }
 
-  get dict(): IHash<number | boolean | string | Binary> {
-    const dictionary: IHash<number | boolean | string | Binary> = {};
+  get dict(): Record<string, number | boolean | string | Binary> {
+    const dictionary: Record<string, number | boolean | string | Binary> = {};
     this.data.forEach((entry) => (dictionary[entry.key] = entry.value));
     return dictionary;
   }

--- a/src/transactions/Statement.ts
+++ b/src/transactions/Statement.ts
@@ -13,12 +13,12 @@ const VAR_BYTES = 256;
 const DEFAULT_VERSION = 3;
 
 export default class Statement extends Transaction {
-  public static readonly TYPE = 23;
+  static readonly TYPE = 23;
 
-  public statementType: number;
-  public recipient?: string;
-  public subject?: Binary;
-  public data: DataEntry[] = [];
+  statementType: number;
+  recipient?: string;
+  subject?: Binary;
+  data: DataEntry[] = [];
 
   constructor(
     statementType: number,
@@ -61,7 +61,7 @@ export default class Statement extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -72,7 +72,7 @@ export default class Statement extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -94,13 +94,13 @@ export default class Statement extends Transaction {
     };
   }
 
-  public get dict(): IHash<number | boolean | string | Binary> {
+  get dict(): IHash<number | boolean | string | Binary> {
     const dictionary: IHash<number | boolean | string | Binary> = {};
     this.data.forEach((entry) => (dictionary[entry.key] = entry.value));
     return dictionary;
   }
 
-  public static from(data: ITxJSON): Statement {
+  static from(data: ITxJSON): Statement {
     const tx = new Statement(
       data.associationType,
       data.recipient,

--- a/src/transactions/Transaction.ts
+++ b/src/transactions/Transaction.ts
@@ -4,19 +4,19 @@ import { ISigner, ITxJSON, TKeyType } from '../../interfaces';
 import { getNetwork } from '../utils/crypto';
 
 export default abstract class Transaction {
-  public id?: string;
-  public readonly type: number;
-  public version: number;
-  public fee: number;
-  public timestamp?: number;
-  public proofs: Array<string> = [];
-  public sender?: string;
-  public senderKeyType: TKeyType = 'ed25519';
-  public senderPublicKey?: string;
-  public sponsor?: string;
-  public sponsorKeyType?: string;
-  public sponsorPublicKey?: string;
-  public height?: number;
+  id?: string;
+  readonly type: number;
+  version: number;
+  fee: number;
+  timestamp?: number;
+  proofs: Array<string> = [];
+  sender?: string;
+  senderKeyType: TKeyType = 'ed25519';
+  senderPublicKey?: string;
+  sponsor?: string;
+  sponsorKeyType?: string;
+  sponsorPublicKey?: string;
+  height?: number;
 
   protected constructor(type: number, version: number, fee = 0) {
     this.type = type;
@@ -28,11 +28,11 @@ export default abstract class Transaction {
 
   abstract toJSON(): ITxJSON;
 
-  public isSigned(): boolean {
+  isSigned(): boolean {
     return this.proofs.length != 0;
   }
 
-  public signWith(account: ISigner): this {
+  signWith(account: ISigner): this {
     if (!this.timestamp) this.timestamp = Date.now();
 
     if (!this.sender) {
@@ -52,12 +52,12 @@ export default abstract class Transaction {
     return this;
   }
 
-  public get chainId(): string {
+  get chainId(): string {
     if (!this.sender) throw new Error('Chain id unknown');
     return getNetwork(this.sender);
   }
 
-  public broadcastTo(node: PublicNode): Promise<this> {
+  broadcastTo(node: PublicNode): Promise<this> {
     if (this.isSigned()) {
       return node.broadcast(this);
     }
@@ -66,7 +66,7 @@ export default abstract class Transaction {
     return node.submit(this);
   }
 
-  public sponsorWith(sponsorAccount: ISigner): this {
+  sponsorWith(sponsorAccount: ISigner): this {
     if (!this.isSigned()) throw new Error('Transaction must be signed first');
 
     if (this.sponsor) this.proofs.pop(); // The sponsor is replaced. The last proof is from the old sponsor.

--- a/src/transactions/Transfer.ts
+++ b/src/transactions/Transfer.ts
@@ -10,11 +10,11 @@ const DEFAULT_FEE = 100000000;
 const DEFAULT_VERSION = 3;
 
 export default class Transfer extends Transaction {
-  public static readonly TYPE = 4;
+  static readonly TYPE = 4;
 
-  public recipient: string;
-  public amount: number;
-  public attachment: Binary;
+  recipient: string;
+  amount: number;
+  attachment: Binary;
 
   constructor(recipient: string | ISigner, amount: number, attachment: Uint8Array | string = '') {
     super(Transfer.TYPE, DEFAULT_VERSION, DEFAULT_FEE);
@@ -52,7 +52,7 @@ export default class Transfer extends Transaction {
     );
   }
 
-  public toBinary(): Uint8Array {
+  toBinary(): Uint8Array {
     if (!this.sender) throw Error('Transaction sender not set');
 
     switch (this.version) {
@@ -65,7 +65,7 @@ export default class Transfer extends Transaction {
     }
   }
 
-  public toJSON(): ITxJSON {
+  toJSON(): ITxJSON {
     return {
       id: this.id,
       type: this.type,
@@ -86,7 +86,7 @@ export default class Transfer extends Transaction {
     };
   }
 
-  public static from(data: ITxJSON): Transfer {
+  static from(data: ITxJSON): Transfer {
     const attachment = data.attachment ? Binary.fromBase58(data.attachment) : '';
     return new Transfer(data.recipient, data.amount, attachment).initFrom(data);
   }

--- a/test/identities/AccountResolver.spec.ts
+++ b/test/identities/AccountResolver.spec.ts
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { AccountResolver } from '../../src/identities';
+import { Account } from '../../src/accounts';
+
+describe('AccountResolver', () => {
+  const address = '3N7RAo9eXFhJEdpPgbhsAFti8s1HDxxXiCW';
+  const publicKey = '3ct1eeZg1ryzz24VHk4CigJxW6Adxh7Syfm459CmGNv2';
+  const networkId = 'T';
+  const url = 'https://example.com/1.0/identifiers';
+
+  describe('#resolve', () => {
+    it('should resolve an account', async () => {
+      const didDocument = {
+        id: `did:lto:${address}`,
+        verificationMethod: [
+          {
+            id: `did:lto:${address}#sign`,
+            type: 'Ed25519VerificationKey2018',
+            publicKeyBase58: publicKey,
+          },
+        ],
+      };
+
+      const accountResolver = new AccountResolver(networkId, url);
+      const fetchStub = sinon
+        .stub(accountResolver as any, 'fetch')
+        .resolves({ ok: true, status: 200, json: () => Promise.resolve(didDocument) });
+
+      const account = await accountResolver.resolve(address);
+
+      expect(fetchStub.calledOnceWithExactly(`${url}/${address}`, { method: 'GET' })).to.be.true;
+      expect(account).to.be.an.instanceOf(Account);
+      expect(account.publicKey).to.equal(publicKey);
+    });
+
+    it('should throw an error for unknown public key', async () => {
+      const errorResponse = { error: 'notFound' };
+
+      const accountResolver = new AccountResolver(networkId, url);
+      const fetchStub = sinon
+        .stub(accountResolver as any, 'fetch')
+        .resolves({ status: 404, json: () => Promise.resolve(errorResponse) });
+
+      try {
+        await accountResolver.resolve(address);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(fetchStub.calledOnceWithExactly(`${url}/${address}`, { method: 'GET' })).to.be.true;
+        expect(error.message).to.equal(`Public key of ${address} is unknown`);
+      }
+    });
+
+    it('should throw an error for missing public sign key', async () => {
+      const didDocument = {
+        id: `did:lto:${address}`,
+        verificationMethod: [
+          {
+            id: `did:lto:${address}#verify`,
+            type: 'EcdsaSecp256k1VerificationKey2019',
+            publicKeyBase58: publicKey,
+          },
+        ],
+      };
+
+      const accountResolver = new AccountResolver(networkId, url);
+      const fetchStub = sinon
+        .stub(accountResolver as any, 'fetch')
+        .resolves({ ok: true, status: 200, json: () => Promise.resolve(didDocument) });
+
+      try {
+        await accountResolver.resolve(address);
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(fetchStub.calledOnceWithExactly(`${url}/${address}`, { method: 'GET' })).to.be.true;
+        expect(error.message).to.equal(`Public sign key for ${address} not found in DID document 'did:lto:${address}'`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
- Omit public for properties and methods
- Browse the repository at this point in the history
- Support encrypted en unencrypted messages.
- Browse the repository at this point in the history
- Use Record type instead of custom IHash
- Browse the repository at this point in the history
- Added AccountResolver. 
- Uses DID resolver to resolve an address into a public key account.