### PR TITLE
Break change to DID verification method association

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -110,6 +110,13 @@ export interface IDIDService {
   [key: string]: any;
 }
 
+export type TDIDRelationship =
+  | 'authentication'
+  | 'assertionMethod'
+  | 'keyAgreement'
+  | 'capabilityInvocation'
+  | 'capabilityDelegation';
+
 // Missing interfaces
 declare global {
   interface Window {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,5 @@ export const DEFAULT_RELAY_SERVICE = 'https://relay.lto.network';
 export const DEFAULT_DERIVATION_PATH = "m/44'/118'/0'/0/0";
 
 export const DEFAULT_MESSAGE_TYPE = 'basic';
+
+export const ASSOCIATION_TYPE_DID_VERIFICATION_METHOD = 0x100;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,4 +14,5 @@ export const DEFAULT_DERIVATION_PATH = "m/44'/118'/0'/0/0";
 
 export const DEFAULT_MESSAGE_TYPE = 'basic';
 
+export const STATEMENT_TYPE_REVOKE_DID = 0x20;
 export const ASSOCIATION_TYPE_DID_VERIFICATION_METHOD = 0x100;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,5 +14,5 @@ export const DEFAULT_DERIVATION_PATH = "m/44'/118'/0'/0/0";
 
 export const DEFAULT_MESSAGE_TYPE = 'basic';
 
-export const STATEMENT_TYPE_REVOKE_DID = 0x20;
 export const ASSOCIATION_TYPE_DID_VERIFICATION_METHOD = 0x100;
+export const STATEMENT_TYPE_REVOKE_DID = 0x101;

--- a/src/identities/IdentityBuilder.ts
+++ b/src/identities/IdentityBuilder.ts
@@ -73,13 +73,7 @@ export default class IdentityBuilder {
         method.account.address,
         undefined,
         method.expires,
-        {
-          authentication: !!method.relationship.includes('authentication'),
-          assertionMethod: !!method.relationship.includes('assertionMethod'),
-          keyAgreement: !!method.relationship.includes('keyAgreement'),
-          capabilityInvocation: !!method.relationship.includes('capabilityInvocation'),
-          capabilityDelegation: !!method.relationship.includes('capabilityDelegation'),
-        },
+        this.relationshipsAsData(method.relationship),
       );
       txs.push(tx.signWith(this.account));
     }
@@ -90,6 +84,10 @@ export default class IdentityBuilder {
     }
 
     return txs;
+  }
+
+  private relationshipsAsData(relationship: TDIDRelationship[]) {
+    return Object.fromEntries(relationship.map((rel) => [rel, true]));
   }
 
   private getServiceTx(): Transaction {

--- a/src/identities/IdentityBuilder.ts
+++ b/src/identities/IdentityBuilder.ts
@@ -36,7 +36,8 @@ export default class IdentityBuilder {
   }
 
   addService(service: IDIDService): this {
-    service.id ??= `${this.account.did}#${service.type}`;
+    service.id ??=
+      `${this.account.did}#` + service.type.replace(/([a-z])(?=[A-Z])|([A-Z])(?=[A-Z][a-z])/g, '$1$2-').toLowerCase();
 
     this.newServices.push(service);
     return this;
@@ -73,7 +74,7 @@ export default class IdentityBuilder {
         method.account.address,
         undefined,
         method.expires,
-        this.relationshipsAsData(method.relationship),
+        Object.fromEntries(method.relationship.map((rel) => [rel, true])),
       );
       txs.push(tx.signWith(this.account));
     }
@@ -84,10 +85,6 @@ export default class IdentityBuilder {
     }
 
     return txs;
-  }
-
-  private relationshipsAsData(relationship: TDIDRelationship[]) {
-    return Object.fromEntries(relationship.map((rel) => [rel, true]));
   }
 
   private getServiceTx(): Transaction {

--- a/src/identities/IdentityBuilder.ts
+++ b/src/identities/IdentityBuilder.ts
@@ -7,7 +7,7 @@ import { ASSOCIATION_TYPE_DID_VERIFICATION_METHOD } from '../constants';
 export default class IdentityBuilder {
   readonly account: Account;
   readonly newMethods: { account: Account; relationship: TDIDRelationship[]; expires?: Date }[] = [];
-  readonly removedMethods: { account: Account }[] = [];
+  readonly removedMethods: string[] = [];
   readonly newServices: IDIDService[] = [];
   readonly removedServices: string[] = [];
 
@@ -27,8 +27,11 @@ export default class IdentityBuilder {
     return this;
   }
 
-  removeVerificationMethod(secondaryAccount: Account): this {
-    this.removedMethods.push({ account: secondaryAccount });
+  removeVerificationMethod(secondaryAccount: Account | string): this {
+    const address =
+      secondaryAccount instanceof Account ? secondaryAccount.address : secondaryAccount.replace(/^did:lto:|#.*$/g, '');
+
+    this.removedMethods.push(address);
     return this;
   }
 
@@ -81,8 +84,8 @@ export default class IdentityBuilder {
       txs.push(tx.signWith(this.account));
     }
 
-    for (const method of this.removedMethods) {
-      const tx = new RevokeAssociation(ASSOCIATION_TYPE_DID_VERIFICATION_METHOD, method.account.address);
+    for (const address of this.removedMethods) {
+      const tx = new RevokeAssociation(ASSOCIATION_TYPE_DID_VERIFICATION_METHOD, address);
       txs.push(tx.signWith(this.account));
     }
 

--- a/src/identities/IdentityBuilder.ts
+++ b/src/identities/IdentityBuilder.ts
@@ -1,8 +1,8 @@
 import { Account } from '../accounts';
-import { Anchor, Association, Data, Register, RevokeAssociation } from '../transactions';
+import { Anchor, Association, Data, Register, RevokeAssociation, Statement } from '../transactions';
 import Transaction from '../transactions/Transaction';
 import { IDIDService, TDIDRelationship } from '../../interfaces';
-import { ASSOCIATION_TYPE_DID_VERIFICATION_METHOD } from '../constants';
+import { ASSOCIATION_TYPE_DID_VERIFICATION_METHOD, STATEMENT_TYPE_REVOKE_DID } from '../constants';
 
 export default class IdentityBuilder {
   readonly account: Account;
@@ -104,5 +104,10 @@ export default class IdentityBuilder {
     });
 
     return new Data(Object.fromEntries([...entries, ...removeEntries])).signWith(this.account);
+  }
+
+  revokeDID(reason?: string): Statement {
+    const data = reason ? { reason } : {};
+    return new Statement(STATEMENT_TYPE_REVOKE_DID, undefined, undefined, data).signWith(this.account);
   }
 }

--- a/src/identities/index.ts
+++ b/src/identities/index.ts
@@ -1,11 +1,2 @@
 export { default as IdentityBuilder } from './IdentityBuilder';
 export { default as AccountResolver } from './AccountResolver';
-
-export enum VerificationRelationship {
-  none = 0x100,
-  authentication = 0x101,
-  assertion = 0x102,
-  keyAgreement = 0x104,
-  capabilityInvocation = 0x108,
-  capabilityDelegation = 0x110,
-}

--- a/src/transactions/Statement.ts
+++ b/src/transactions/Statement.ts
@@ -22,14 +22,14 @@ export default class Statement extends Transaction {
 
   constructor(
     statementType: number,
-    recipient: string | ISigner,
+    recipient?: string | ISigner,
     subject?: Uint8Array,
     data: Record<string, number | boolean | string | Uint8Array> | DataEntry[] = [],
   ) {
     super(Statement.TYPE, DEFAULT_VERSION);
 
     this.statementType = statementType;
-    this.recipient = typeof recipient === 'string' ? recipient : recipient.address;
+    if (recipient) this.recipient = typeof recipient === 'string' ? recipient : recipient.address;
     if (subject) this.subject = new Binary(subject);
 
     this.data = Array.isArray(data) ? data : dictToData(data);

--- a/test/identities/IdentityBuilder.spec.ts
+++ b/test/identities/IdentityBuilder.spec.ts
@@ -84,7 +84,7 @@ describe('IdentityBuilder', () => {
 
   describe('addService', () => {
     const builder = new IdentityBuilder(account)
-      .addService({ type: 'foo', serviceEndpoint: 'https://example.com/foo' })
+      .addService({ type: 'LTORelay', serviceEndpoint: 'ampq://example.com' })
       .addService({ id: `${account.did}#abcdef`, type: 'bar', serviceEndpoint: 'https://example.com/bar' })
       .addService({
         id: `id:123`,
@@ -111,9 +111,9 @@ describe('IdentityBuilder', () => {
       });
 
       assert.deepInclude(entries, {
-        key: `did:service:foo`,
+        key: `did:service:lto-relay`,
         type: 'string',
-        value: { id: `${account.did}#foo`, type: 'foo', serviceEndpoint: 'https://example.com/foo' },
+        value: { id: `${account.did}#lto-relay`, type: 'LTORelay', serviceEndpoint: 'ampq://example.com' },
       });
 
       assert.deepInclude(entries, {

--- a/test/identities/IdentityBuilder.spec.ts
+++ b/test/identities/IdentityBuilder.spec.ts
@@ -1,10 +1,12 @@
 // noinspection DuplicatedCode
 
 import { assert, expect } from 'chai';
-import { IdentityBuilder, VerificationRelationship as VR } from '../../src/identities';
+import { IdentityBuilder } from '../../src/identities';
 import { AccountFactoryED25519 as AccountFactory } from '../../src/accounts';
 import { Register, Association, Anchor } from '../../src/transactions';
-import { Data } from '../../src';
+import { Data, RevokeAssociation } from '../../src';
+import DataEntry from '../../src/transactions/DataEntry';
+import { ASSOCIATION_TYPE_DID_VERIFICATION_METHOD } from '../../src/constants';
 
 const primaryPhrase =
   'satisfy sustain shiver skill betray mother appear pupil coconut weasel firm top puzzle monkey seek';
@@ -19,7 +21,7 @@ describe('IdentityBuilder', () => {
   describe('addVerificationMethod', () => {
     const builder = new IdentityBuilder(account)
       .addVerificationMethod(secondaryAccount1)
-      .addVerificationMethod(secondaryAccount2, VR.authentication | VR.capabilityInvocation);
+      .addVerificationMethod(secondaryAccount2, ['authentication', 'capabilityInvocation']);
     const txs = builder.transactions;
 
     it('should create 3 transactions', () => {
@@ -40,37 +42,42 @@ describe('IdentityBuilder', () => {
       const assocTxs = txs.filter((tx) => tx.type === Association.TYPE) as Array<Association>;
       assert.lengthOf(assocTxs, 2);
 
-      assert.equal(assocTxs[0].type, 16);
-      assert.equal(assocTxs[0].associationType, VR.none);
-      assert.equal(assocTxs[0].recipient, secondaryAccount1.address);
-      assert.equal(assocTxs[0].sender, account.address);
+      const tx1: Association = assocTxs[0];
+      assert.equal(tx1.type, Association.TYPE);
+      assert.equal(tx1.associationType, ASSOCIATION_TYPE_DID_VERIFICATION_METHOD);
+      assert.equal(tx1.recipient, secondaryAccount1.address);
+      assert.equal(tx1.sender, account.address);
+      assert.deepInclude(tx1.data, { key: 'authentication', type: 'boolean', value: false } as DataEntry);
+      assert.deepInclude(tx1.data, { key: 'assertionMethod', type: 'boolean', value: false } as DataEntry);
+      assert.deepInclude(tx1.data, { key: 'keyAgreement', type: 'boolean', value: false } as DataEntry);
+      assert.deepInclude(tx1.data, { key: 'capabilityInvocation', type: 'boolean', value: false } as DataEntry);
+      assert.deepInclude(tx1.data, { key: 'capabilityDelegation', type: 'boolean', value: false } as DataEntry);
 
-      assert.equal(assocTxs[1].type, 16);
-      assert.equal(assocTxs[1].associationType, VR.authentication | VR.capabilityInvocation);
-      assert.equal(assocTxs[1].recipient, secondaryAccount2.address);
-      assert.equal(assocTxs[1].sender, account.address);
+      const tx2: Association = assocTxs[1];
+      assert.equal(tx2.type, Association.TYPE);
+      assert.equal(tx2.associationType, ASSOCIATION_TYPE_DID_VERIFICATION_METHOD);
+      assert.equal(tx2.recipient, secondaryAccount2.address);
+      assert.equal(tx2.sender, account.address);
+      assert.deepInclude(tx2.data, { key: 'authentication', type: 'boolean', value: true } as DataEntry);
+      assert.deepInclude(tx2.data, { key: 'assertionMethod', type: 'boolean', value: false } as DataEntry);
+      assert.deepInclude(tx2.data, { key: 'keyAgreement', type: 'boolean', value: false } as DataEntry);
+      assert.deepInclude(tx2.data, { key: 'capabilityInvocation', type: 'boolean', value: true } as DataEntry);
+      assert.deepInclude(tx2.data, { key: 'capabilityDelegation', type: 'boolean', value: false } as DataEntry);
     });
   });
 
-  describe('addVerificationMethod with named relationships', () => {
-    const builder = new IdentityBuilder(account)
-      .addVerificationMethod(secondaryAccount1, ['assertion'])
-      .addVerificationMethod(secondaryAccount2, ['authentication', 'capabilityInvocation']);
+  describe('removeVerificationMethod', () => {
+    const builder = new IdentityBuilder(account).removeVerificationMethod(secondaryAccount1);
     const txs = builder.transactions;
 
-    it('should create two association transactions', () => {
-      const assocTxs = txs.filter((tx) => tx.type === Association.TYPE) as Array<Association>;
-      assert.lengthOf(assocTxs, 2);
+    it('should create a revoke association transactions', () => {
+      assert.lengthOf(txs, 1);
+      assert.equal(txs[0].type, RevokeAssociation.TYPE);
 
-      assert.equal(assocTxs[0].type, 16);
-      assert.equal(assocTxs[0].associationType, VR.assertion);
-      assert.equal(assocTxs[0].recipient, secondaryAccount1.address);
-      assert.equal(assocTxs[0].sender, account.address);
-
-      assert.equal(assocTxs[1].type, 16);
-      assert.equal(assocTxs[1].associationType, VR.authentication | VR.capabilityInvocation);
-      assert.equal(assocTxs[1].recipient, secondaryAccount2.address);
-      assert.equal(assocTxs[1].sender, account.address);
+      const tx = txs[0] as RevokeAssociation;
+      assert.equal(tx.associationType, ASSOCIATION_TYPE_DID_VERIFICATION_METHOD);
+      assert.equal(tx.recipient, secondaryAccount1.address);
+      assert.equal(tx.sender, account.address);
     });
   });
 
@@ -118,6 +125,49 @@ describe('IdentityBuilder', () => {
         key: `did:service:id:123`,
         type: 'string',
         value: { id: 'id:123', type: 'qux', serviceEndpoint: 'https://example.com/qux', description: 'QUX' },
+      });
+    });
+  });
+
+  describe('removeService', () => {
+    const builder = new IdentityBuilder(account)
+      .addService({ type: 'foo', serviceEndpoint: 'https://example.com/foo' })
+      .removeService(`${account.did}#abcdef`)
+      .removeService('id:123');
+    const txs = builder.transactions;
+
+    it('should create 1 data transaction', () => {
+      assert.lengthOf(txs, 1);
+      assert.equal(txs[0].type, Data.TYPE);
+    });
+
+    it('should have the correct data entries', () => {
+      const tx = txs[0] as Data;
+
+      const entries = tx.data.map((entry) => {
+        return {
+          key: entry.key,
+          type: entry.type,
+          value: typeof entry.value === 'string' ? JSON.parse(entry.value) : entry.value,
+        };
+      });
+
+      assert.deepInclude(entries, {
+        key: `did:service:foo`,
+        type: 'string',
+        value: { id: `${account.did}#foo`, type: 'foo', serviceEndpoint: 'https://example.com/foo' },
+      });
+
+      assert.deepInclude(entries, {
+        key: `did:service:abcdef`,
+        type: 'boolean',
+        value: false,
+      });
+
+      assert.deepInclude(entries, {
+        key: `did:service:id:123`,
+        type: 'boolean',
+        value: false,
       });
     });
   });

--- a/test/identities/IdentityBuilder.spec.ts
+++ b/test/identities/IdentityBuilder.spec.ts
@@ -48,11 +48,6 @@ describe('IdentityBuilder', () => {
       assert.equal(tx1.recipient, secondaryAccount1.address);
       assert.equal(tx1.sender, account.address);
       assert.equal(tx1.expires, new Date('2030-01-01T00:00:00.000Z').getTime());
-      assert.deepInclude(tx1.data, { key: 'authentication', type: 'boolean', value: false } as DataEntry);
-      assert.deepInclude(tx1.data, { key: 'assertionMethod', type: 'boolean', value: false } as DataEntry);
-      assert.deepInclude(tx1.data, { key: 'keyAgreement', type: 'boolean', value: false } as DataEntry);
-      assert.deepInclude(tx1.data, { key: 'capabilityInvocation', type: 'boolean', value: false } as DataEntry);
-      assert.deepInclude(tx1.data, { key: 'capabilityDelegation', type: 'boolean', value: false } as DataEntry);
 
       const tx2: Association = assocTxs[1];
       assert.equal(tx2.type, Association.TYPE);
@@ -61,10 +56,7 @@ describe('IdentityBuilder', () => {
       assert.equal(tx2.sender, account.address);
       assert.isUndefined(tx2.expires);
       assert.deepInclude(tx2.data, { key: 'authentication', type: 'boolean', value: true } as DataEntry);
-      assert.deepInclude(tx2.data, { key: 'assertionMethod', type: 'boolean', value: false } as DataEntry);
-      assert.deepInclude(tx2.data, { key: 'keyAgreement', type: 'boolean', value: false } as DataEntry);
       assert.deepInclude(tx2.data, { key: 'capabilityInvocation', type: 'boolean', value: true } as DataEntry);
-      assert.deepInclude(tx2.data, { key: 'capabilityDelegation', type: 'boolean', value: false } as DataEntry);
     });
   });
 

--- a/test/identities/IdentityBuilder.spec.ts
+++ b/test/identities/IdentityBuilder.spec.ts
@@ -3,10 +3,10 @@
 import { assert, expect } from 'chai';
 import { IdentityBuilder } from '../../src/identities';
 import { AccountFactoryED25519 as AccountFactory } from '../../src/accounts';
-import { Register, Association, Anchor } from '../../src/transactions';
+import { Register, Association, Anchor, Statement } from '../../src/transactions';
 import { Data, RevokeAssociation } from '../../src';
 import DataEntry from '../../src/transactions/DataEntry';
-import { ASSOCIATION_TYPE_DID_VERIFICATION_METHOD } from '../../src/constants';
+import { ASSOCIATION_TYPE_DID_VERIFICATION_METHOD, STATEMENT_TYPE_REVOKE_DID } from '../../src/constants';
 
 const primaryPhrase =
   'satisfy sustain shiver skill betray mother appear pupil coconut weasel firm top puzzle monkey seek';
@@ -182,7 +182,8 @@ describe('IdentityBuilder', () => {
   });
 
   describe('no additional verification methods or services', () => {
-    const txs = new IdentityBuilder(account).transactions;
+    const builder = new IdentityBuilder(account);
+    const txs = builder.transactions;
 
     it('should create 1 transaction', () => {
       assert.lengthOf(txs, 1);
@@ -194,6 +195,27 @@ describe('IdentityBuilder', () => {
       assert.equal(anchorTx.type, Anchor.TYPE);
       assert.equal(anchorTx.sender, account.address);
       assert.lengthOf(anchorTx.anchors, 0);
+    });
+  });
+
+  describe('revoke', () => {
+    const builder = new IdentityBuilder(account);
+
+    it('should create a statement transaction', () => {
+      const tx = builder.revokeDID();
+
+      assert.equal(tx.type, Statement.TYPE);
+      assert.equal(tx.sender, account.address);
+      assert.equal(tx.statementType, STATEMENT_TYPE_REVOKE_DID);
+    });
+
+    it('should create a statement transaction with a reason', () => {
+      const tx = builder.revokeDID('reason');
+
+      assert.equal(tx.type, Statement.TYPE);
+      assert.equal(tx.sender, account.address);
+      assert.equal(tx.statementType, STATEMENT_TYPE_REVOKE_DID);
+      assert.deepInclude(tx.data, { key: 'reason', type: 'string', value: 'reason' } as DataEntry);
     });
   });
 });


### PR DESCRIPTION
Change association type for verification method.
Assoc type is always 0x100.
The verification relationships are set data entries.
Added `removeVerificationMethod` to identity builder. This revokes the association.
Added `removeService()`

BREAKING CHANGE!
