### PR TITLE
Support base64 encoded nonce in `LTO.account()`

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -8,7 +8,7 @@ export interface IAccountIn {
   keyType?: string;
   seed?: string;
   seedPassword?: string;
-  nonce?: number | Uint8Array;
+  nonce?: number | string | Uint8Array;
   derivationPath?: string;
   parent?: {
     seed: string;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "mocha": "10.2.0",
+    "nyc": "^15.1.0",
     "prettier": "^2.8.7",
     "requirejs": "2.3.6",
     "sinon": "15.0.4",

--- a/src/accounts/AccountFactory.ts
+++ b/src/accounts/AccountFactory.ts
@@ -2,11 +2,7 @@ import Account from './Account';
 import { int32ToBytes } from '../utils/bytes';
 
 export default abstract class AccountFactory {
-  readonly chainId: string;
-
-  protected constructor(chainId: string) {
-    this.chainId = chainId;
-  }
+  protected constructor(readonly networkId: string) {}
 
   abstract createFromPublicKey(publicKey: string | Uint8Array): Account;
 

--- a/src/accounts/ecdsa/AccountFactoryECDSA.ts
+++ b/src/accounts/ecdsa/AccountFactoryECDSA.ts
@@ -16,8 +16,8 @@ export default class AccountFactoryECDSA extends AccountFactory {
   readonly curve: 'secp256k1' | 'secp256r1';
   private readonly ec: typeof secp256k1;
 
-  constructor(chainId: string, curve: 'secp256k1' | 'secp256r1') {
-    super(chainId);
+  constructor(networkId: string, curve: 'secp256k1' | 'secp256r1') {
+    super(networkId);
     this.curve = curve;
     this.ec = this.curve === 'secp256k1' ? secp256k1 : secp256r1;
   }
@@ -58,7 +58,7 @@ export default class AccountFactoryECDSA extends AccountFactory {
       uncompressed.publicKey = publicKeyBinary;
     }
 
-    const address = buildAddress(compressed.publicKey, this.chainId);
+    const address = buildAddress(compressed.publicKey, this.networkId);
     const cypher = new ECDSA(this.curve, uncompressed);
     return new Account(cypher, address, compressed, compressed);
   }
@@ -85,7 +85,7 @@ export default class AccountFactoryECDSA extends AccountFactory {
     };
 
     const cypher = new ECDSA(this.curve, uncompressed);
-    const address = buildAddress(compressed.publicKey, this.chainId);
+    const address = buildAddress(compressed.publicKey, this.networkId);
 
     return new Account(cypher, address, compressed, compressed, seed, nonce);
   }

--- a/src/accounts/ed25519/AccountFactoryED25519.ts
+++ b/src/accounts/ed25519/AccountFactoryED25519.ts
@@ -16,8 +16,8 @@ export default class AccountFactoryED25519 extends AccountFactory {
   sign: IKeyPairBytes;
   encrypt: IKeyPairBytes;
 
-  constructor(chainId: string) {
-    super(chainId);
+  constructor(networkId: string) {
+    super(networkId);
   }
 
   createFromSeed(seed: string, nonce: number | Uint8Array = 0): Account {
@@ -32,7 +32,7 @@ export default class AccountFactoryED25519 extends AccountFactory {
     };
 
     const cypher = new ED25519(sign, encrypt);
-    const address = buildAddress(sign.publicKey, this.chainId);
+    const address = buildAddress(sign.publicKey, this.networkId);
 
     return new Account(cypher, address, sign, encrypt, seed, nonce);
   }
@@ -49,7 +49,7 @@ export default class AccountFactoryED25519 extends AccountFactory {
     };
 
     const cypher = new ED25519(sign, encrypt);
-    const address = buildAddress(sign.publicKey, this.chainId);
+    const address = buildAddress(sign.publicKey, this.networkId);
 
     return new Account(cypher, address, sign, encrypt);
   }
@@ -65,7 +65,7 @@ export default class AccountFactoryED25519 extends AccountFactory {
     };
 
     const cypher = new ED25519(sign, encrypt);
-    const address = buildAddress(sign.publicKey, this.chainId);
+    const address = buildAddress(sign.publicKey, this.networkId);
 
     return new Account(cypher, address, sign, encrypt);
   }

--- a/src/utils/encrypt-seed.ts
+++ b/src/utils/encrypt-seed.ts
@@ -1,8 +1,9 @@
 import * as AES from 'crypto-js/aes';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { SEED_ENCRYPTION_ROUNDS } from '../constants';
 
-function strengthenPassword(password: string, rounds = 5000): string {
+function strengthenPassword(password: string, rounds = SEED_ENCRYPTION_ROUNDS): string {
   while (rounds--) password = bytesToHex(sha256(password));
   return password;
 }

--- a/test/LTO.spec.ts
+++ b/test/LTO.spec.ts
@@ -1,6 +1,241 @@
-import LTO from '../src/';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import LTO, { Binary, encryptSeed } from '../src';
+import { PublicNode } from '../src/node';
+import { Relay } from '../src/messages';
+import { Account, AccountFactory, AccountFactoryECDSA, AccountFactoryED25519 } from '../src/accounts';
 
 describe('LTO', () => {
-  // Test creation: is publicNode and nodeAddress set for the network
-  // Test changing node address, did the publicNode change? And visa versa
+  let lto: LTO;
+
+  beforeEach(() => {
+    lto = new LTO('T');
+  });
+
+  describe('constructor', () => {
+    it('should set the network id', () => {
+      expect(lto.networkId).to.equal('T');
+    });
+
+    it('should set the default node and node address', () => {
+      expect(lto.nodeAddress).to.equal('https://testnet.lto.network');
+
+      expect(lto.node).to.be.instanceOf(PublicNode);
+      expect(lto.node.url).to.equal('https://testnet.lto.network');
+      expect(lto.node.apiKey).to.equal('');
+    });
+
+    it('should set the default relay', () => {
+      expect(lto.relay).to.be.instanceOf(Relay);
+      expect(lto.relay.url).to.equal('https://relay.lto.network');
+    });
+
+    it('should initialize account factories', () => {
+      expect(lto.accountFactories).to.be.an('object');
+
+      // Check for each type of account factory
+      expect(lto.accountFactories.ed25519).to.be.an.instanceOf(AccountFactoryED25519);
+      expect(lto.accountFactories.secp256r1).to.be.an.instanceOf(AccountFactoryECDSA);
+      expect(lto.accountFactories.secp256k1).to.be.an.instanceOf(AccountFactoryECDSA);
+
+      // Ensure factories have correct networkId
+      expect(lto.accountFactories.ed25519.networkId).to.equal('T');
+      expect(lto.accountFactories.secp256r1.networkId).to.equal('T');
+      expect(lto.accountFactories.secp256k1.networkId).to.equal('T');
+    });
+
+    it('should accept a custom network id', () => {
+      lto = new LTO('L');
+
+      expect(lto.networkId).to.equal('L');
+
+      expect(lto.nodeAddress).to.equal('https://nodes.lto.network');
+      expect(lto.node).to.be.instanceOf(PublicNode);
+      expect(lto.node.url).to.equal('https://nodes.lto.network');
+    });
+
+    it('should not set default node for an unknown network id', () => {
+      lto = new LTO('Z');
+
+      expect(lto.networkId).to.equal('Z');
+
+      expect(() => lto.node).to.throw('Public node not configured');
+      expect(() => lto.nodeAddress).to.throw('Public node not configured');
+    });
+  });
+
+  describe('account', () => {
+    let mockFactory: sinon.SinonStubbedInstance<AccountFactoryED25519>;
+    let mockFactoryECDSA: sinon.SinonStubbedInstance<AccountFactoryECDSA>;
+    let mockAccount: sinon.SinonStubbedInstance<Account>;
+
+    beforeEach(() => {
+      mockFactory = sinon.createStubInstance(AccountFactoryED25519);
+      mockFactoryECDSA = sinon.createStubInstance(AccountFactoryECDSA);
+
+      lto.accountFactories = {
+        ed25519: mockFactory,
+        secp256r1: mockFactoryECDSA,
+        secp256k1: mockFactoryECDSA,
+      } as any;
+    });
+
+    beforeEach(() => {
+      mockAccount = sinon.createStubInstance(Account);
+      (mockAccount as any).address = 'testAddress';
+      sinon.stub(mockAccount, 'privateKey').get(() => 'testPrivateKey');
+      sinon.stub(mockAccount, 'publicKey').get(() => 'testPublicKey');
+
+      mockFactory.create.returns(mockAccount);
+      mockFactory.createFromSeed.returns(mockAccount);
+      mockFactory.createFromPrivateKey.returns(mockAccount);
+      mockFactory.createFromPublicKey.returns(mockAccount);
+
+      mockFactoryECDSA.create.returns(mockAccount);
+      mockFactoryECDSA.createFromSeed.returns(mockAccount);
+      mockFactoryECDSA.createFromPrivateKey.returns(mockAccount);
+      mockFactoryECDSA.createFromPublicKey.returns(mockAccount);
+    });
+
+    it('should create a random account', () => {
+      expect(lto.account()).to.equal(mockAccount);
+      expect(mockFactory.create.calledOnce).to.be.true;
+    });
+
+    it('should create account from privateKey', () => {
+      const settings = { privateKey: 'testPrivateKey' };
+      expect(lto.account(settings)).to.equal(mockAccount);
+      expect(mockFactory.createFromPrivateKey.calledWith(settings.privateKey)).to.be.true;
+    });
+
+    it('should create account from publicKey', () => {
+      const settings = { publicKey: 'testPublicKey' };
+      expect(lto.account(settings)).to.equal(mockAccount);
+      expect(mockFactory.createFromPublicKey.calledWith(settings.publicKey)).to.be.true;
+    });
+
+    describe('from seed', () => {
+      it('should create account from seed', () => {
+        const settings = { seed: 'testSeed' };
+        expect(lto.account(settings)).to.equal(mockAccount);
+        expect(mockFactory.createFromSeed.calledWith(settings.seed, undefined)).to.be.true;
+      });
+
+      it('should create account from seed and nonce', () => {
+        const settings = { seed: 'testSeed', nonce: 1 };
+        expect(lto.account(settings)).to.equal(mockAccount);
+        expect(mockFactory.createFromSeed.calledWith(settings.seed, settings.nonce)).to.be.true;
+      });
+
+      it('should create account from seed and binary nonce', () => {
+        const settings = { seed: 'testSeed', nonce: Uint8Array.from([1, 2, 3]) };
+        expect(lto.account(settings)).to.equal(mockAccount);
+        expect(mockFactory.createFromSeed.calledWith(settings.seed, settings.nonce)).to.be.true;
+      });
+
+      it('should create account from seed and binary nonce', () => {
+        const settings = { seed: 'testSeed', nonce: 'base64:dGVzdA==' };
+        expect(lto.account(settings)).to.equal(mockAccount);
+        expect(mockFactory.createFromSeed.calledWith(settings.seed, new Binary('test'))).to.be.true;
+      });
+
+      it('should create account from encrypted seed', () => {
+        const seed = encryptSeed('testSeed', 'testPassword');
+        const settings = { seed, seedPassword: 'testPassword' };
+
+        expect(lto.account(settings)).to.equal(mockAccount);
+        expect(mockFactory.createFromSeed.calledWith('testSeed', undefined)).to.be.true;
+      });
+
+      it('should create account from parent', () => {
+        const seed = 'mock parent seed';
+        const mockParentAccount = sinon.createStubInstance(Account);
+        (mockParentAccount as any).seed = seed;
+
+        const settings = { parent: mockParentAccount, nonce: 1 };
+        const account = lto.account(settings);
+
+        expect(account).to.equal(mockAccount);
+        expect(mockFactory.createFromSeed.calledWith(seed, 1)).to.be.true;
+        expect(account.parent).to.equal(mockParentAccount);
+      });
+
+      it('should create account from parent seed', () => {
+        const mockParentAccount = sinon.createStubInstance(Account);
+        mockFactory.createFromSeed.onCall(0).returns(mockAccount);
+        mockFactory.createFromSeed.onCall(1).returns(mockParentAccount);
+
+        const settings = { parent: { seed: 'parentSeed' }, nonce: 1 };
+        const account = lto.account(settings);
+
+        expect(account).to.equal(mockAccount);
+        expect(mockFactory.createFromSeed.calledWith(settings.parent.seed, undefined)).to.be.true;
+        expect(mockFactory.createFromSeed.calledWith(settings.parent.seed, 1)).to.be.true;
+      });
+
+      it('should create a random account with specific derivation path', () => {
+        const settings = { derivationPath: `m/44'/60'/0'/0` };
+
+        expect(lto.account(settings)).to.equal(mockAccount);
+        expect(mockFactory.createFromSeed.calledWith('', new Binary(settings.derivationPath))).to.be.true;
+      });
+
+      it('should throw error for invalid nonce', () => {
+        expect(() => lto.account({ nonce: 'invalid' })).to.throw(
+          'Invalid nonce: must be a number, binary value, or base64 string prefixed with "base64:"',
+        );
+      });
+    });
+
+    describe('with keyType', () => {
+      it('should throw error for invalid key type', () => {
+        expect(() => lto.account({ keyType: 'invalid' })).to.throw('Invalid key type: invalid');
+      });
+
+      for (const keyType of ['ed25519', 'secp256k1']) {
+        let expectedFactory: sinon.SinonStubbedInstance<AccountFactory>;
+
+        beforeEach(() => {
+          expectedFactory = keyType === 'ed25519' ? mockFactory : mockFactoryECDSA;
+        });
+
+        it(`should create a random ${keyType} account`, () => {
+          lto.account({ keyType });
+          expect(expectedFactory.create.calledOnce).to.be.true;
+        });
+
+        it(`should create an ${keyType} account from seed`, () => {
+          lto.account({ seed: 'testSeed', keyType });
+          expect(expectedFactory.createFromSeed.calledOnce).to.be.true;
+        });
+
+        it(`should create an ${keyType} account from private key`, () => {
+          lto.account({ privateKey: 'testPrivateKey', keyType });
+          expect(expectedFactory.createFromPrivateKey.calledOnce).to.be.true;
+        });
+
+        it(`should create an ${keyType} account from public key`, () => {
+          lto.account({ publicKey: 'testPublicKey', keyType });
+          expect(expectedFactory.createFromPublicKey.calledOnce).to.be.true;
+        });
+      }
+    });
+
+    describe('guard', () => {
+      it('should throw error when privateKey does not match account privateKey', () => {
+        expect(() => lto.account({ privateKey: 'differentPrivateKey' })).to.throw('Private key mismatch');
+        expect(() => lto.account({ privateKey: new Binary('differentPrivateKey') })).to.throw('Private key mismatch');
+      });
+
+      it('should throw error when publicKey does not match account publicKey', () => {
+        expect(() => lto.account({ publicKey: 'differentPublicKey' })).to.throw('Public key mismatch');
+        expect(() => lto.account({ publicKey: new Binary('differentPublicKey') })).to.throw('Public key mismatch');
+      });
+
+      it('should throw error when address does not match account address', () => {
+        expect(() => lto.account({ address: 'differentAddress' })).to.throw('Address mismatch');
+      });
+    });
+  });
 });


### PR DESCRIPTION
```
const account = lto.account({ seed: 'testSeed', nonce: 'base64:dGVzdA==' });
```

Unit tests for `LTO.account()`
Minor fixes