### PR TITLE
Fix issue with long messages

### DIFF
--- a/src/messages/Message.ts
+++ b/src/messages/Message.ts
@@ -216,14 +216,14 @@ export default class Message {
 
     if (encrypted) {
       message._encryptedData = new Binary(byteArrayWithSizeToBytes(data.slice(offset), 'int32'));
-      offset += message._encryptedData.length + 2;
+      offset += message._encryptedData.length + 4;
     } else {
       const mediaTypeBytes = byteArrayWithSizeToBytes(data.slice(offset));
       message.mediaType = new Binary(mediaTypeBytes).toString();
       offset += mediaTypeBytes.length + 2;
 
       message.data = new Binary(byteArrayWithSizeToBytes(data.slice(offset), 'int32'));
-      offset += message.data.length + 2;
+      offset += message.data.length + 4;
     }
 
     const signature = data.slice(offset);

--- a/src/messages/Message.ts
+++ b/src/messages/Message.ts
@@ -47,9 +47,9 @@ export default class Message {
     if (typeof data === 'string') {
       this.mediaType = mediaType ?? 'text/plain';
       this.data = new Binary(data);
-    } else if (data instanceof Binary) {
+    } else if (data instanceof Uint8Array) {
       this.mediaType = mediaType ?? 'application/octet-stream';
-      this.data = data;
+      this.data = data instanceof Binary ? data : new Binary(data);
     } else {
       if (mediaType && mediaType !== 'application/json') throw new Error(`Unable to encode data as ${mediaType}`);
 
@@ -128,8 +128,8 @@ export default class Message {
     if (!this.sender || !this.timestamp || (withSignature && !this.signature)) throw new Error('Message not signed');
 
     const data = this._encryptedData
-      ? bytesToByteArrayWithSize(this._encryptedData)
-      : concatBytes(stringToByteArrayWithSize(this.mediaType), bytesToByteArrayWithSize(this.data));
+      ? bytesToByteArrayWithSize(this._encryptedData, 'int32')
+      : concatBytes(stringToByteArrayWithSize(this.mediaType), bytesToByteArrayWithSize(this.data, 'int32'));
 
     return concatBytes(
       stringToByteArrayWithSize(this.type),
@@ -215,14 +215,14 @@ export default class Message {
     const encrypted = data[offset++] === 1;
 
     if (encrypted) {
-      message._encryptedData = new Binary(byteArrayWithSizeToBytes(data.slice(offset)));
+      message._encryptedData = new Binary(byteArrayWithSizeToBytes(data.slice(offset), 'int32'));
       offset += message._encryptedData.length + 2;
     } else {
       const mediaTypeBytes = byteArrayWithSizeToBytes(data.slice(offset));
       message.mediaType = new Binary(mediaTypeBytes).toString();
       offset += mediaTypeBytes.length + 2;
 
-      message.data = new Binary(byteArrayWithSizeToBytes(data.slice(offset)));
+      message.data = new Binary(byteArrayWithSizeToBytes(data.slice(offset), 'int32'));
       offset += message.data.length + 2;
     }
 

--- a/src/types/accounts.d.ts
+++ b/src/types/accounts.d.ts
@@ -12,8 +12,8 @@ export interface IAccountIn {
   nonce?: number | string | Uint8Array;
   derivationPath?: string;
   parent?: {
-    seed: string;
-    keyType?: string;
+    seed?: string;
+    keyType?: TKeyType;
   };
 }
 

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -38,3 +38,11 @@ export function int16ToBytes(value: number): Uint8Array {
   bytes[0] = (value >> 8) & 0xff;
   return bytes;
 }
+
+export function bytesToInt(bytes: Uint8Array): number {
+  let value = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    value += bytes[i] << (8 * (bytes.length - i - 1));
+  }
+  return value;
+}

--- a/test/message/Message.spec.ts
+++ b/test/message/Message.spec.ts
@@ -44,6 +44,14 @@ describe('Message', () => {
       expect(message.mediaType).to.equal(mediaType);
     });
 
+    it('should initialize the message with Uint8Array', () => {
+      const data = new TextEncoder().encode('test');
+      const message = new Message(data);
+
+      expect(message.data.toString()).to.equal('test');
+      expect(message.mediaType).to.equal('application/octet-stream');
+    });
+
     it('should initialize the message with JSON data', () => {
       const data = { message: 'test' };
       const message = new Message(data);
@@ -116,7 +124,7 @@ describe('Message', () => {
 
       expect(binary).to.be.instanceOf(Uint8Array);
       expect(new Binary(binary).hex).to.equal(
-        '000562617369630126e86176189975fcd29ea0b912a9f7b8f8ef668815fe131ff1507a2664d273ef015423b61593a085a642b8c63e509aa65e74eadafada8acf462c000001856aa0c80000000a746578742f706c61696e0004746573748dd0e7ab7b2f55a73255b4a46b7d776593c9fb9cc5fc379b996de741a3685208f12adedb741eb3a6fb61c0300a7458681f126f82c1adf8a3d6dd3b4f0bbca00e',
+        '000562617369630126e86176189975fcd29ea0b912a9f7b8f8ef668815fe131ff1507a2664d273ef015423b61593a085a642b8c63e509aa65e74eadafada8acf462c000001856aa0c80000000a746578742f706c61696e0000000474657374b13b2efa259c39ab273816fdb6ff815392f64bd6662116ca14ff42f084a2320de91789775d38b88fe4f9fb02f0ca9dedbf40bb7a6e417e6a41a03b12bbcb730a',
       );
     });
 
@@ -193,7 +201,7 @@ describe('Message', () => {
       message.to(recipient);
       message.signWith(sender);
 
-      expect(message.hash.hex).to.equal('309acd29a4a64caa84b0736e7472cf141fc7f5bed27f4f923deb3f508b916f61');
+      expect(message.hash.hex).to.equal('1220671d512353807324d97a8531d6b29e0274e6b8f0131d3ba1064328123f47');
       expect(message.verifyHash()).to.be.true;
     });
 
@@ -330,7 +338,7 @@ describe('Message', () => {
       const message = Message.from(data);
 
       expect(message.isSigned()).to.be.false;
-      expect(message.hash.hex).to.equal('b72bb07c32fad1ec316dc65d51982accc5fc091cb60eed6a0ded6fa46b1afa0b');
+      expect(message.hash.hex).to.equal('ea27da76668aa63430b65f907c78d2d4f48a0c144239e4b75eb98978cd248720');
     });
   });
 });


### PR DESCRIPTION
If the data of a message is longer than 65535 bytes, it's truncated because the field of the length is an int16.

* Change the length field to be int32 for data/encryptedData.
* Check if the response of the relay service is a 200 OK, otherwise throw an error.
* Allow any UInt8Array as argument for the Message contructor, no need to explicitly convert it to a `Binary` object.