### PR TITLE
Use 742 in derivation path for secp256k1 key generation.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ export const DEFAULT_MAINNET_NODE = 'https://nodes.lto.network';
 export const DEFAULT_TESTNET_NODE = 'https://testnet.lto.network';
 export const DEFAULT_RELAY_SERVICE = 'https://relay.lto.network';
 
-export const DEFAULT_DERIVATION_PATH = "m/44'/118'/0'/0/0";
+export const DEFAULT_DERIVATION_PATH = "m/44'/742'/0'/0/0";
 
 export const DEFAULT_MESSAGE_TYPE = 'basic';
 

--- a/test/accounts/secp256k1.spec.ts
+++ b/test/accounts/secp256k1.spec.ts
@@ -10,8 +10,8 @@ describe('secp256k1 account', () => {
   const otherSeed =
     'library ride board swallow route salmon country love luggage beyond all attract crunch burger field';
 
-  const privKey = '6dJNhZ9njLAPPsrwtjqhcA3xzgWQC96JuNiRfEuZ1FRs';
-  const pubKey = 'k6kUC53X8vQRrNxe9fKqrNg91TVLcejZ2YyJvKprGbfd';
+  const privKey = 'DRpStYEzVkHs8WRGz9zcxRoudhnYzeGzJ6JVVWFcrbsA';
+  const pubKey = 'yBUTnq2bLomxJSrQTMgD9CLKLLzKxZCMTH2naizoBpcZ';
   const message = 'hello';
 
   const factory = new AccountFactoryECDSA('T', 'secp256k1');


### PR DESCRIPTION
LTO Network has obtained its own SLIP-0044 type `742`. This is set as the default instead of Cosmos `118` for bep39.

See https://github.com/satoshilabs/slips/pull/1892

:warning: Generating an secp256k1 keyset without providing a derivation path will result in different keys and address.